### PR TITLE
use --export=None + don't use custom `$EESSI_INIT` in Snellius config file

### DIFF
--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -16,7 +16,7 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': ['source /cvmfs/pilot.eessi-hpc.org/latest/init/bash'],
                     'launcher': 'mpirun',
-                    'access':  ['-p thin --exclusive'],
+                    'access':  ['-p thin', '--export=None'],
                     'environs': ['default'],
                     'max_jobs': 120,
                     'processor': {
@@ -33,9 +33,9 @@ site_configuration = {
                 {
                     'name': 'gpu',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source $EESSI_INIT'],
+                    'prepare_cmds': ['source /cvmfs/pilot.eessi-hpc.org/latest/init/bash'],
                     'launcher': 'srun',
-                    'access':  ['-p gpu'],
+                    'access':  ['-p gpu', '--export=None'],
                     'environs': ['default'],
                     'max_jobs': 60,
                     'processor': {


### PR DESCRIPTION
Don't use EESSI_INIT env var, its something I set personally. Add --export=None, even if this is the default on our system, it is a good practice to ensure this