### PR TITLE
filter valid_systems on gpu_vendor extras

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,16 +43,14 @@ jobs:
             export RFM_SYSTEM=github_actions_eessi
             export RFM_CHECK_SEARCH_PATH=$PWD/eessi/testsuite/tests/apps
 
-            # show active ReFrame configuration,
-            # enable verbose output to help expose problems with configuration file (if any)
-            reframe -vvv --show-config
-
             # update $PYTHONPATH so 'import eessi.testsuite.utils' works
             export PYTHONPATH=$PWD:$PYTHONPATH
             echo $PYTHONPATH
-            pwd
-            ls -hl
             python -c 'import eessi.testsuite.utils'
+
+            # show active ReFrame configuration,
+            # enable verbose output to help expose problems with configuration file (if any)
+            reframe -vvv --show-config
 
             # perform a dry run of *all* tests, without any filtering
             time reframe --dry-run 2>&1 | tee dry_run.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,10 @@ jobs:
 
             # update $PYTHONPATH so 'import eessi.testsuite.utils' works
             export PYTHONPATH=$PWD:$PYTHONPATH
+            echo $PYTHONPATH
+            pwd
+            ls -hl
+            python -c 'import eessi.testsuite.utils'
 
             # perform a dry run of *all* tests, without any filtering
             time reframe --dry-run 2>&1 | tee dry_run.out

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ reframe \
     ```
     'access': ['-p <partition_name>'],
     'devices': [
-        {'type': DEVICES[GPU], 'num_devices': <x>}
+        {'type': DEVICE_TYPES[GPU], 'num_devices': <x>}
     ],
     ```
 - requesting GPUs per node for a partition:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Alternatively, you can clone the repository
 git clone git@github.com:EESSI/test-suite.git
 ```
 
-- update your ``$PYTHONPATH`` so that it includes the path of the ``test-suite`` directory
+- add the path of the `test-suite` directory to your ``$PYTHONPATH``
 
 - create a site configuration file
 
@@ -25,9 +25,11 @@ git clone git@github.com:EESSI/test-suite.git
 
 - run the tests
 
-    The example below runs a gromacs simulation using GROMACS modules available in the system,
-    in combination with all available system:partitions as defined in the site config file.
-    This example assumes that you have cloned the repository at `/path/to/EESSI/test-suite`.
+    The example below runs a gromacs simulation using GROMACS modules available
+    in the system, in combination with all available system:partitions as
+    defined in the site config file, using 1 full node (`--tag 1_node`, see `SCALES`
+    in `constants.py`).  This example assumes that you have cloned the
+    repository at `/path/to/EESSI/test-suite`.
 
 ```
 cd /path/to/EESSI/test-suite
@@ -46,16 +48,15 @@ reframe \
 ## Configuring GPU/non-GPU partitions in your site config file:
 
 - running GPU jobs in GPU nodes
-    - add feature `gpu` to the GPU partitions
+    - add `'features': [gpu]` to the GPU partitions
+    - add `'extras': {'gpu_vendor': 'nvidia'}` to the GPU partitions (or
+      `'intel'` or `'amd'`, see `GPU_VENDORS` in `constants.py`)
 
 - running non-GPU jobs in non-GPU nodes
     - add feature `cpu` to the non-GPU partitions
 
 - running GPU jobs and non-GPU jobs on gpu nodes
-    - add both features `cpu` and `gpu` to the GPU partitions
-    ```
-    'features': ['cpu', 'gpu'],
-    ```
+    - add `'features': ['cpu', 'gpu']` to the GPU partitions
 
 - setting the number of GPUS per node <x> for a partition:
     ```
@@ -79,8 +80,12 @@ reframe \
 - specifying modules
     - `--setvar modules=<modulename>`
 
-- specifying systems:partitions
+- specifying valid systems:partitions
     - `--setvar valid_systems=<comma-separated-list>`
+
+      Note that setting `valid_systems` on the cmd line disables filtering of
+      valid systems:partitions in the hooks, so you have to do the filtering
+      yourself.
 
 - overriding tasks, cpus, gpus
     - `--setvar num_tasks_per_node=<x>`
@@ -90,11 +95,17 @@ reframe \
 - setting additional environment variables
     - `--setvar env_vars=<envar>:<value>`
 
-Note that these override the variables for _all_ tests in the test suite that respect those variables. To override a variable only for specific tests, one can use the `TEST.VAR` syntax. E.g. to run the GROMACS_EESSI test, with the module `GROMACS/2021.6-foss-2022a`:
-    - `--setvar GROMACS_EESSI.modules=GROMACS/2021.6-foss-2022a'
+Note that these override the variables for _all_ tests in the test suite that
+respect those variables. To override a variable only for specific tests, one
+can use the `TEST.VAR` syntax. For example, to run the `GROMACS_EESSI` test with the
+module `GROMACS/2021.6-foss-2022a`:
+
+- `--setvar GROMACS_EESSI.modules=GROMACS/2021.6-foss-2022a'
 
 ## Developers
-If you want to install the EESSI test suite from a branch, you can either install the feature branch with `pip`, or clone the Github repository and check out the feature branch.
+If you want to install the EESSI test suite from a branch, you can either
+install the feature branch with `pip`, or clone the Github repository and check
+out the feature branch.
 
 ### Install from branch with pip
 
@@ -104,14 +115,17 @@ To install from one of the branches of the main repository, use:
 pip install git+https://github.com/EESSI/test-suite.git@branchname
 ```
 
-Generally, you'll want to do this from a forked repository though, where someone worked on a feature. E.g.
+Generally, you'll want to do this from a forked repository though, where
+someone worked on a feature. E.g.
 
 ```bash
 pip install git+https://github.com/<someuser>/test-suite.git@branchname
 ```
 
 ### Check out a feature branch from a fork
-We'll assume you already have a local clone of the official test-suite repository, called 'origin'. In that case, executing `git remote -v`, you should see:
+We'll assume you already have a local clone of the official test-suite
+repository, called 'origin'. In that case, executing `git remote -v`, you
+should see:
 
 ```bash
 $ git remote -v
@@ -119,7 +133,10 @@ origin  git@github.com:EESSI/test-suite.git (fetch)
 origin  git@github.com:EESSI/test-suite.git (push)
 ```
 
-You can add a fork to your local clone by adding a new remote. Pick a name for the remote that you find easy to recognize. E.g. to add the fork https://github.com/casparvl/test-suite and give it the (local) name `casparvl`, run:
+You can add a fork to your local clone by adding a new remote. Pick a name for
+the remote that you find easy to recognize. E.g. to add the fork
+https://github.com/casparvl/test-suite and give it the (local) name `casparvl`,
+run:
 
 ```bash
 git remote add casparvl git@github.com:casparvl/test-suite.git
@@ -152,11 +169,18 @@ $ git branch --list --remotes
   origin/main
 ```
 
-(remember to re-run `git fetch <remote>` if new branches don't show up with this command).
+(remember to re-run `git fetch <remote>` if new branches don't show up with
+this command).
 
-Finally, we can create a new local branch (`-c`) and checkout one of these feature branches (e.g. `setuppy` from the remote `casparvl`). Here, we've picked `local_setuppy_branch` as the local branch name:
+Finally, we can create a new local branch (`-c`) and checkout one of these
+feature branches (e.g. `setuppy` from the remote `casparvl`). Here, we've
+picked `local_setuppy_branch` as the local branch name:
 ```bash
 $ git switch -c local_setuppy_branch casparvl/setuppy
 ```
 
-While the initial setup is a bit more involved, the advantage of this approach is that it is easy to pull in updates from a feature branch using `git pull`. You can also push back changes to the feature branch directly, but note that you are pushing to the Github fork of another Github user, so _make sure they are ok with that_ before doing so!
+While the initial setup is a bit more involved, the advantage of this approach
+is that it is easy to pull in updates from a feature branch using `git pull`.
+You can also push back changes to the feature branch directly, but note that
+you are pushing to the Github fork of another Github user, so _make sure they
+are ok with that_ before doing so!

--- a/README.md
+++ b/README.md
@@ -48,21 +48,21 @@ reframe \
 ## Configuring GPU/non-GPU partitions in your site config file:
 
 - running GPU jobs in GPU nodes
-    - add `'features': [gpu]` to the GPU partitions
-    - add `'extras': {'gpu_vendor': 'nvidia'}` to the GPU partitions (or
-      `'intel'` or `'amd'`, see `GPU_VENDORS` in `constants.py`)
+    - add `'features': [FEATURES[GPU]]` to the GPU partitions
+    - add `'extras': {GPU_VENDOR: GPU_VENDORS[NVIDIA]}` to the GPU partitions (or
+      `INTEL` or `AMD`, see `GPU_VENDORS` in `constants.py`)
 
 - running non-GPU jobs in non-GPU nodes
-    - add feature `cpu` to the non-GPU partitions
+    - add `'features': [FEATURES[CPU]]` to the non-GPU partitions
 
-- running GPU jobs and non-GPU jobs on gpu nodes
-    - add `'features': ['cpu', 'gpu']` to the GPU partitions
+- running both GPU jobs and non-GPU jobs in GPU nodes
+    - add `'features': [FEATURES[CPU], FEATURES[GPU]]` to the GPU partitions
 
 - setting the number of GPUS per node <x> for a partition:
     ```
     'access': ['-p <partition_name>'],
     'devices': [
-        {'type': 'gpu', 'num_devices': <x>}
+        {'type': DEVICES[GPU], 'num_devices': <x>}
     ],
     ```
 - requesting GPUs per node for a partition:
@@ -100,7 +100,7 @@ respect those variables. To override a variable only for specific tests, one
 can use the `TEST.VAR` syntax. For example, to run the `GROMACS_EESSI` test with the
 module `GROMACS/2021.6-foss-2022a`:
 
-- `--setvar GROMACS_EESSI.modules=GROMACS/2021.6-foss-2022a'
+- `--setvar GROMACS_EESSI.modules=GROMACS/2021.6-foss-2022a`
 
 ## Developers
 If you want to install the EESSI test suite from a branch, you can either

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -1,4 +1,8 @@
 # ReFrame configuration file that can be used in GitHub Actions with EESSI
+
+from eessi.testsuite.constants import *
+
+
 site_configuration = {
     'systems': [
         {
@@ -12,7 +16,7 @@ site_configuration = {
                     'scheduler': 'local',
                     'launcher': 'local',
                     'environs': ['default'],
-                    'features': ['cpu'],
+                    'features': [FEATURES[CPU]],
                     'processor': {'num_cpus': 2},
                     'max_jobs': 1
                     }

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -48,7 +48,7 @@ site_configuration = {
                     'type': 'file',
                     'level': 'debug',
                     'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
-                    'append': False
+                    'append': True
                     }
                 ],
             'handlers_perflog': [

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -3,7 +3,8 @@ Example configuration file
 """
 from os import environ
 
-from eessi.testsuite.constants import DEVICES, FEATURES, GPU_VENDORS
+from eessi.testsuite.constants import *
+
 
 username = environ.get('USER')
 
@@ -30,7 +31,7 @@ site_configuration = {
                         'num_cpus_per_socket': 64,
                         'arch': 'zen2',
                     },
-                    'features': [FEATURES['CPU']],
+                    'features': [FEATURES[CPU]],
                     'descr': 'CPU partition'
                 },
                 {
@@ -54,16 +55,16 @@ site_configuration = {
                     ],
                     'devices': [
                         {
-                            'type': DEVICES['GPU'],
+                            'type': DEVICES[GPU],
                             'num_devices': 4,
                         }
                     ],
                     'features': [
-                        FEATURES['CPU'],
-                        FEATURES['GPU'],
+                        FEATURES[CPU],
+                        FEATURES[GPU],
                     ],
                     'extras': {
-                        'gpu_vendor': GPU_VENDORS['NVIDIA'],
+                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
                     },
                     'descr': 'GPU partition'
                 },

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -93,7 +93,8 @@ site_configuration = {
                     'name': 'reframe.log',
                     'level': 'debug',
                     'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
-                    'append': False
+                    'append': True,
+                    'timestamp': "%Y%m%d_%H%M%S",
                 }
             ],
             'handlers_perflog': [

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -55,7 +55,7 @@ site_configuration = {
                     ],
                     'devices': [
                         {
-                            'type': DEVICES[GPU],
+                            'type': DEVICE_TYPES[GPU],
                             'num_devices': 4,
                         }
                     ],

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -10,7 +10,7 @@ username = environ.get('USER')
 site_configuration = {
     'systems': [
         {
-            'name': 'examle',
+            'name': 'example',
             'descr': 'Example cluster',
             'modules_system': 'lmod',
             'hostnames': ['*'],
@@ -58,8 +58,13 @@ site_configuration = {
                             'num_devices': 4,
                         }
                     ],
-                    'features': [FEATURES['CPU'], FEATURES['GPU']],
-                    'extras': {'gpu_vendor': GPU_VENDORS['NVIDIA']},
+                    'features': [
+                        FEATURES['CPU'],
+                        FEATURES['GPU'],
+                    ],
+                    'extras': {
+                        'gpu_vendor': GPU_VENDORS['NVIDIA'],
+                    },
                     'descr': 'GPU partition'
                 },
             ]

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -3,7 +3,7 @@ Example configuration file
 """
 from os import environ
 
-from eessi.testsuite.constants import DEVICES, FEATURES
+from eessi.testsuite.constants import DEVICES, FEATURES, GPU_VENDORS
 
 username = environ.get('USER')
 
@@ -59,6 +59,7 @@ site_configuration = {
                         }
                     ],
                     'features': [FEATURES['CPU'], FEATURES['GPU']],
+                    'extras': {'gpu_vendor': GPU_VENDORS['NVIDIA']},
                     'descr': 'GPU partition'
                 },
             ]

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -90,7 +90,8 @@ site_configuration = {
                     'name': 'reframe.log',
                     'level': 'debug',
                     'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
-                    'append': False
+                    'append': True,
+                    'timestamp': "%Y%m%d_%H%M%S",
                 }
             ],
             'handlers_perflog': [

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -8,7 +8,7 @@ site_configuration = {
             'name': 'snellius',
             'descr': 'Dutch National Supercomputer',
             'modules_system': 'lmod',
-            'hostnames': ['int*','tcn*','hcn*','fcn*','gcn*','srv*'],
+            'hostnames': ['int*', 'tcn*', 'hcn*', 'fcn*', 'gcn*', 'srv*'],
             'stagedir': f'/scratch-shared/{username}/reframe_output/staging',
             'partitions': [
                 {
@@ -59,11 +59,14 @@ site_configuration = {
                     'features': [
                         'gpu',
                     ],
+                    'extras': {
+                        'gpu_vendor': 'nvidia',
+                    },
                     'descr': 'Test GPU partition with native EESSI stack'
                 },
-             ]
-         },
-     ],
+            ]
+        },
+    ],
     'environments': [
         {
             'name': 'default',
@@ -71,8 +74,8 @@ site_configuration = {
             'cxx': '',
             'ftn': '',
         },
-     ],
-     'logging': [
+    ],
+    'logging': [
         {
             'level': 'debug',
             'handlers': [

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -1,4 +1,8 @@
 from os import environ
+
+from eessi.testsuite.constants import *
+
+
 username = environ.get('USER')
 
 # This is an example configuration file
@@ -26,7 +30,7 @@ site_configuration = {
                         'arch': 'zen2',
                     },
                     'features': [
-                        'cpu',
+                        FEATURES[CPU],
                     ],
                     'descr': 'Test CPU partition with native EESSI stack'
                 },
@@ -46,7 +50,7 @@ site_configuration = {
                     },
                     'devices': [
                         {
-                            'type': 'gpu',
+                            'type': DEVICES[GPU],
                             'num_devices': 4,
                         }
                     ],
@@ -57,10 +61,10 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        'gpu',
+                        FEATURES[GPU],
                     ],
                     'extras': {
-                        'gpu_vendor': 'nvidia',
+                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
                     },
                     'descr': 'Test GPU partition with native EESSI stack'
                 },

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -50,7 +50,7 @@ site_configuration = {
                     },
                     'devices': [
                         {
-                            'type': DEVICES[GPU],
+                            'type': DEVICE_TYPES[GPU],
                             'num_devices': 4,
                         }
                     ],

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -138,7 +138,7 @@ site_configuration = {
                     ],
                     'devices': [
                        {
-                            'type': DEVICES[GPU],
+                            'type': DEVICE_TYPES[GPU],
                             'num_devices': 4,
                         }
                     ],
@@ -173,7 +173,7 @@ site_configuration = {
                     ],
                     'devices': [
                         {
-                            'type': DEVICES[GPU],
+                            'type': DEVICE_TYPES[GPU],
                             'num_devices': 4,
                         }
                     ],

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -223,7 +223,8 @@ site_configuration = {
                     'name': 'reframe.log',
                     'level': 'debug',
                     'format': '[%(asctime)s] %(levelname)s: %(check_name)s: %(message)s',  # noqa: E501
-                    'append': False,
+                    'append': True,
+                    'timestamp': "%Y%m%d_%H%M%S",
                 },
                 {
                     'type': 'stream',
@@ -236,7 +237,8 @@ site_configuration = {
                     'name': 'reframe.out',
                     'level': 'info',
                     'format': '%(message)s',
-                    'append': False,
+                    'append': True,
+                    'timestamp': "%Y%m%d_%H%M%S",
                 },
             ],
             'handlers_perflog': [

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -6,6 +6,9 @@
 from reframe.core.backends import register_launcher
 from reframe.core.launchers import JobLauncher
 
+from eessi.testsuite.constants import *
+
+
 account = "my-slurm-account"
 
 # use 'info' to log to syslog
@@ -65,7 +68,7 @@ site_configuration = {
                         'arch': 'zen2',
                     },
                     'features': [
-                        'cpu',
+                        FEATURES[CPU],
                     ],
                 },
                 {
@@ -84,7 +87,7 @@ site_configuration = {
                         'arch': 'zen2',
                     },
                     'features': [
-                        'cpu',
+                        FEATURES[CPU],
                     ],
                 },
                 {
@@ -103,7 +106,7 @@ site_configuration = {
                         'arch': 'zen3',
                     },
                     'features': [
-                        'cpu',
+                        FEATURES[CPU],
                     ],
                 },
                 {
@@ -122,10 +125,10 @@ site_configuration = {
                         'arch': 'zen2',
                     },
                     'features': [
-                        'gpu',
+                        FEATURES[GPU],
                     ],
                     'extras': {
-                        'gpu_vendor': 'nvidia',
+                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
                     },
                     'resources': [
                         {
@@ -135,7 +138,7 @@ site_configuration = {
                     ],
                     'devices': [
                        {
-                            'type': 'gpu',
+                            'type': DEVICES[GPU],
                             'num_devices': 4,
                         }
                     ],
@@ -157,10 +160,10 @@ site_configuration = {
                         'arch': 'zen2',
                     },
                     'features': [
-                        'gpu',
+                        FEATURES[GPU],
                     ],
                     'extras': {
-                        'gpu_vendor': 'nvidia',
+                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
                     },
                     'resources': [
                         {
@@ -170,7 +173,7 @@ site_configuration = {
                     ],
                     'devices': [
                         {
-                            'type': 'gpu',
+                            'type': DEVICES[GPU],
                             'num_devices': 4,
                         }
                     ],

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -124,6 +124,9 @@ site_configuration = {
                     'features': [
                         'gpu',
                     ],
+                    'extras': {
+                        'gpu_vendor': 'nvidia',
+                    },
                     'resources': [
                         {
                             'name': '_rfm_gpu',
@@ -156,6 +159,9 @@ site_configuration = {
                     'features': [
                         'gpu',
                     ],
+                    'extras': {
+                        'gpu_vendor': 'nvidia',
+                    },
                     'resources': [
                         {
                             'name': '_rfm_gpu',

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -2,8 +2,8 @@
 Constants for ReFrame tests
 """
 DEVICES = {
-    'GPU': 'gpu',
     'CPU': 'cpu',
+    'GPU': 'gpu',
 }
 
 TAGS = {
@@ -11,8 +11,14 @@ TAGS = {
 }
 
 FEATURES = {
-    'GPU': 'gpu',
     'CPU': 'cpu',
+    'GPU': 'gpu',
+}
+
+GPU_VENDORS = {
+    'AMD': 'amd',
+    'INTEL': 'intel',
+    'NVIDIA': 'nvidia',
 }
 
 SCALES = {

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -9,7 +9,7 @@ GPU_VENDOR = 'GPU_VENDOR'
 INTEL = 'INTEL'
 NVIDIA = 'NVIDIA'
 
-DEVICES = {
+DEVICE_TYPES = {
     CPU: 'cpu',
     GPU: 'gpu',
 }

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -1,24 +1,32 @@
 """
 Constants for ReFrame tests
 """
+AMD = 'AMD'
+CI = 'CI'
+CPU = 'CPU'
+GPU = 'GPU'
+GPU_VENDOR = 'GPU_VENDOR'
+INTEL = 'INTEL'
+NVIDIA = 'NVIDIA'
+
 DEVICES = {
-    'CPU': 'cpu',
-    'GPU': 'gpu',
+    CPU: 'cpu',
+    GPU: 'gpu',
 }
 
 TAGS = {
-    'CI': 'CI',
+    CI: 'CI',
 }
 
 FEATURES = {
-    'CPU': 'cpu',
-    'GPU': 'gpu',
+    CPU: 'cpu',
+    GPU: 'gpu',
 }
 
 GPU_VENDORS = {
-    'AMD': 'amd',
-    'INTEL': 'intel',
-    'NVIDIA': 'nvidia',
+    AMD: 'amd',
+    INTEL: 'intel',
+    NVIDIA: 'nvidia',
 }
 
 SCALES = {

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -20,7 +20,7 @@ or manually set in the ReFrame configuration file
 
 def assign_one_task_per_compute_unit(test: rfm.RegressionTest, compute_unit: str):
     """
-    Assign one task per compute unit (DEVICES[CPU] or DEVICES[GPU]).
+    Assign one task per compute unit (DEVICE_TYPES[CPU] or DEVICE_TYPES[GPU]).
     Automatically sets num_tasks, num_tasks_per_node, num_cpus_per_task, and num_gpus_per_node,
     based on the current scale and the current partition’s num_cpus, max_avail_gpus_per_node and num_nodes.
     For GPU tests, one task per GPU is set, and num_cpus_per_task is based on the ratio of CPU-cores/GPUs.
@@ -59,9 +59,9 @@ def assign_one_task_per_compute_unit(test: rfm.RegressionTest, compute_unit: str
 
     log(f'default_num_cpus_per_node set to {test.default_num_cpus_per_node}')
 
-    if compute_unit == DEVICES[GPU]:
+    if compute_unit == DEVICE_TYPES[GPU]:
         _assign_one_task_per_gpu(test)
-    elif compute_unit == DEVICES[CPU]:
+    elif compute_unit == DEVICE_TYPES[CPU]:
         _assign_one_task_per_cpu(test)
     else:
         raise ValueError(f'compute unit {compute_unit} is currently not supported')
@@ -186,17 +186,17 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
 
     is_cuda_module = is_cuda_required_module(test.module_name)
 
-    if is_cuda_module and required_device_type == DEVICES[GPU]:
+    if is_cuda_module and required_device_type == DEVICE_TYPES[GPU]:
         # CUDA modules and when using a GPU require partitions with FEATURES[GPU] feature and
         # GPU_VENDOR=GPU_VENDORS[NVIDIA] extras
         valid_systems = f'+{FEATURES[GPU]} %{GPU_VENDOR}={GPU_VENDORS[NVIDIA]}'
 
-    elif required_device_type == DEVICES[CPU]:
+    elif required_device_type == DEVICE_TYPES[CPU]:
         # Using the CPU requires partitions with FEATURES[CPU] feature
         # Note: making FEATURES[CPU] an explicit feature allows e.g. skipping CPU-based tests on GPU partitions
         valid_systems = f'+{FEATURES[CPU]}'
 
-    elif not is_cuda_module and required_device_type == DEVICES[GPU]:
+    elif not is_cuda_module and required_device_type == DEVICE_TYPES[GPU]:
         # Invalid combination: a module without GPU support cannot use a GPU
         valid_systems = ''
 

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -181,13 +181,14 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
     unless valid_systems is specified with --setvar valid_systems=<comma-separated-list>.
     """
     if test.valid_systems:
-        # valid_systems is specified, don't filter
+        # valid_systems is specified, so don't filter
         return
 
     is_cuda_module = is_cuda_required_module(test.module_name)
 
     if is_cuda_module and required_device_type == DEVICES['GPU']:
-        # CUDA modules and when using a GPU require partitions with 'gpu' feature
+        # CUDA modules and when using a GPU require partitions with 'gpu' feature and
+        # 'gpu_vendor=nvidia' extras
         valid_systems = f'+{FEATURES["GPU"]} %gpu_vendor={GPU_VENDORS["NVIDIA"]}'
 
     elif required_device_type == DEVICES['CPU']:

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -6,7 +6,7 @@ import shlex
 
 import reframe as rfm
 
-from eessi.testsuite.constants import DEVICES, FEATURES, GPU_VENDORS, SCALES
+from eessi.testsuite.constants import *
 from eessi.testsuite.utils import get_max_avail_gpus_per_node, is_cuda_required_module, log
 
 PROCESSOR_INFO_MISSING = '''
@@ -20,7 +20,7 @@ or manually set in the ReFrame configuration file
 
 def assign_one_task_per_compute_unit(test: rfm.RegressionTest, compute_unit: str):
     """
-    Assign one task per compute unit (DEVICES['CPU'] or DEVICES['GPU']).
+    Assign one task per compute unit (DEVICES[CPU] or DEVICES[GPU]).
     Automatically sets num_tasks, num_tasks_per_node, num_cpus_per_task, and num_gpus_per_node,
     based on the current scale and the current partition’s num_cpus, max_avail_gpus_per_node and num_nodes.
     For GPU tests, one task per GPU is set, and num_cpus_per_task is based on the ratio of CPU-cores/GPUs.
@@ -59,9 +59,9 @@ def assign_one_task_per_compute_unit(test: rfm.RegressionTest, compute_unit: str
 
     log(f'default_num_cpus_per_node set to {test.default_num_cpus_per_node}')
 
-    if compute_unit == DEVICES['GPU']:
+    if compute_unit == DEVICES[GPU]:
         _assign_one_task_per_gpu(test)
-    elif compute_unit == DEVICES['CPU']:
+    elif compute_unit == DEVICES[CPU]:
         _assign_one_task_per_cpu(test)
     else:
         raise ValueError(f'compute unit {compute_unit} is currently not supported')
@@ -186,17 +186,17 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
 
     is_cuda_module = is_cuda_required_module(test.module_name)
 
-    if is_cuda_module and required_device_type == DEVICES['GPU']:
-        # CUDA modules and when using a GPU require partitions with 'gpu' feature and
-        # 'gpu_vendor=nvidia' extras
-        valid_systems = f'+{FEATURES["GPU"]} %gpu_vendor={GPU_VENDORS["NVIDIA"]}'
+    if is_cuda_module and required_device_type == DEVICES[GPU]:
+        # CUDA modules and when using a GPU require partitions with FEATURES[GPU] feature and
+        # GPU_VENDOR=GPU_VENDORS[NVIDIA] extras
+        valid_systems = f'+{FEATURES[GPU]} %{GPU_VENDOR}={GPU_VENDORS[NVIDIA]}'
 
-    elif required_device_type == DEVICES['CPU']:
-        # Using the CPU requires partitions with 'cpu' feature
-        # Note: making 'cpu' an explicit feature allows e.g. skipping CPU-based tests on GPU partitions
-        valid_systems = f'+{FEATURES["CPU"]}'
+    elif required_device_type == DEVICES[CPU]:
+        # Using the CPU requires partitions with FEATURES[CPU] feature
+        # Note: making FEATURES[CPU] an explicit feature allows e.g. skipping CPU-based tests on GPU partitions
+        valid_systems = f'+{FEATURES[CPU]}'
 
-    elif not is_cuda_module and required_device_type == DEVICES['GPU']:
+    elif not is_cuda_module and required_device_type == DEVICES[GPU]:
         # Invalid combination: a module without GPU support cannot use a GPU
         valid_systems = ''
 

--- a/eessi/testsuite/utils.py
+++ b/eessi/testsuite/utils.py
@@ -11,7 +11,7 @@ import reframe.core.runtime as rt
 from reframe.frontend.printer import PrettyPrinter
 from reframe.utility import OrderedSet
 
-from eessi.testsuite.constants import DEVICES
+from eessi.testsuite.constants import *
 
 printer = PrettyPrinter()
 
@@ -22,7 +22,7 @@ def log(msg, logger=printer.debug):
 
 
 def _get_gpu_list(test: rfm.RegressionTest) -> list:
-    return [dev.num_devices for dev in test.current_partition.devices if dev.device_type == DEVICES['GPU']]
+    return [dev.num_devices for dev in test.current_partition.devices if dev.device_type == DEVICES[GPU]]
 
 
 def get_max_avail_gpus_per_node(test: rfm.RegressionTest) -> int:
@@ -31,12 +31,12 @@ def get_max_avail_gpus_per_node(test: rfm.RegressionTest) -> int:
     taken from 'num_devices' of device GPU_DEV_NAME in the 'devices' attribute of the current partition
     """
     gpu_list = _get_gpu_list(test)
-    # If multiple devices are called DEVICES['GPU'] in the current partition,
+    # If multiple devices have type DEVICES[GPU] in the current partition,
     # we don't know for which to return the device count...
     if len(gpu_list) != 1:
         partname = test.current_partition.name
         raise ValueError(
-            f"{len(gpu_list)} devices defined in config file with name {DEVICES['GPU']} for partition {partname}. "
+            f"{len(gpu_list)} devices defined in config file with name {DEVICES[GPU]} for partition {partname}. "
             "Cannot determine maximum number of GPUs available for the test. "
             f"Please check the definition of partition {partname} in your ReFrame config file."
         )

--- a/eessi/testsuite/utils.py
+++ b/eessi/testsuite/utils.py
@@ -22,7 +22,7 @@ def log(msg, logger=printer.debug):
 
 
 def _get_gpu_list(test: rfm.RegressionTest) -> list:
-    return [dev.num_devices for dev in test.current_partition.devices if dev.device_type == DEVICES[GPU]]
+    return [dev.num_devices for dev in test.current_partition.devices if dev.device_type == DEVICE_TYPES[GPU]]
 
 
 def get_max_avail_gpus_per_node(test: rfm.RegressionTest) -> int:
@@ -31,12 +31,12 @@ def get_max_avail_gpus_per_node(test: rfm.RegressionTest) -> int:
     taken from 'num_devices' of device GPU_DEV_NAME in the 'devices' attribute of the current partition
     """
     gpu_list = _get_gpu_list(test)
-    # If multiple devices have type DEVICES[GPU] in the current partition,
+    # If multiple devices have type DEVICE_TYPES[GPU] in the current partition,
     # we don't know for which to return the device count...
     if len(gpu_list) != 1:
         partname = test.current_partition.name
         raise ValueError(
-            f"{len(gpu_list)} devices defined in config file with name {DEVICES[GPU]} for partition {partname}. "
+            f"{len(gpu_list)} devices defined in config file with name {DEVICE_TYPES[GPU]} for partition {partname}. "
             "Cannot determine maximum number of GPUs available for the test. "
             f"Please check the definition of partition {partname} in your ReFrame config file."
         )


### PR DESCRIPTION
fixes #34 
fixes #40 

this PR changes `filter_valid_systems_by_device_type` in `hooks.py` to explicitly require an NVIDIA GPU

from
```python
        if is_cuda_module and required_device_type == DEVICES['GPU']:
            # CUDA modules and when using a GPU require partitions with 'gpu' feature
            valid_systems = f'+{FEATURES["GPU"]}'
```
to
```python
    if is_cuda_module and required_device_type == DEVICES['GPU']:
        # CUDA modules and when using a GPU require partitions with 'gpu' feature and
        # 'gpu_vendor=nvidia' extras
        valid_systems = f'+{FEATURES["GPU"]} %gpu_vendor={GPU_VENDORS["NVIDIA"]}'
```