### PR TITLE
use common config section for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ cd /path/to/EESSI/test-suite
 module load ReFrame/4.2.0
 
 export PYTHONPATH=$PWD:$PYTHONPATH
+export RFM_PREFIX=<path_to_all_output>
 
 reframe \
     --config-file <path_to_site_config_file> \
     --checkpath eessi/testsuite/tests/apps \
-    --prefix <path_to_all_output> \
-    --save-log-files \
     --tag CI --tag 1_node \
     --run --performance-report
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ export PYTHONPATH=$PWD:$PYTHONPATH
 reframe \
     --config-file <path_to_site_config_file> \
     --checkpath eessi/testsuite/tests/apps \
+    --prefix <path_to_all_output> \
+    --save-log-files \
     --tag CI --tag 1_node \
     --run --performance-report
 ```

--- a/config/aws_citc.py
+++ b/config/aws_citc.py
@@ -17,6 +17,7 @@ from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import FEATURES
 
 # This config will write all staging, output and logging to subdirs under this prefix
+# Override with RFM_PREFIX environment variable
 reframe_prefix = os.path.join(os.environ['HOME'], 'reframe_runs')
 
 # AWS CITC site configuration

--- a/config/aws_citc.py
+++ b/config/aws_citc.py
@@ -120,6 +120,7 @@ site_configuration = {
     'general': [
         {
             'remote_detect': True,
+            'save_log_files': True,
         }
     ],
 }

--- a/config/aws_citc.py
+++ b/config/aws_citc.py
@@ -16,9 +16,8 @@ import os
 from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import FEATURES
 
-# This config will write all staging, output (and logging with --save-log-files) to subdirs under this prefix
-# Override with --prefix
-reframe_prefix = f'{os.environ.get("HOME")}/reframe_runs'
+# This config will write all staging, output and logging to subdirs under this prefix
+reframe_prefix = os.path.join(os.environ['HOME'], 'reframe_runs')
 
 # AWS CITC site configuration
 site_configuration = {
@@ -116,11 +115,10 @@ site_configuration = {
             'ftn': '',
         },
     ],
-    'logging': common_logging_config,
+    'logging': common_logging_config(reframe_prefix),
     'general': [
         {
             'remote_detect': True,
-            'save_log_files': True,
         }
     ],
 }

--- a/config/aws_citc.py
+++ b/config/aws_citc.py
@@ -11,19 +11,14 @@
 # Another known issue is that CPU autodetection fails if run from an actual installation of ReFrame.
 # It only works if run from a clone of their Github Repo. See https://github.com/reframe-hpc/reframe/issues/2914
 
-from os import environ, makedirs
+import os
 
+from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import FEATURES
 
-# Get username of current user
-homedir = environ.get('HOME')
-
-# This config will write all staging, output and logging to subdirs under this prefix
-reframe_prefix = f'{homedir}/reframe_runs'
-log_prefix = f'{reframe_prefix}/logs'
-
-# ReFrame complains if the directory for the file logger doesn't exist yet
-makedirs(f'{log_prefix}', exist_ok=True)
+# This config will write all staging, output (and logging with --save-log-files) to subdirs under this prefix
+# Override with --prefix
+reframe_prefix = f'{os.environ.get("HOME")}/reframe_runs'
 
 # AWS CITC site configuration
 site_configuration = {
@@ -32,7 +27,7 @@ site_configuration = {
             'name': 'citc',
             'descr': 'Cluster in the Cloud build and test environment on AWS',
             'modules_system': 'lmod',
-    	    'hostnames': ['mgmt', 'login', 'fair-mastodon*'],
+            'hostnames': ['mgmt', 'login', 'fair-mastodon*'],
             'prefix': reframe_prefix,
             'partitions': [
                 {
@@ -110,9 +105,9 @@ site_configuration = {
                     'access': ['--constraint=shape=c7g.4xlarge', '--export=NONE'],
                     'descr': 'Graviton3, 16 cores, 32 GiB',
                 },
-             ]
-         },
-     ],
+            ]
+        },
+    ],
     'environments': [
         {
             'name': 'default',
@@ -120,46 +115,8 @@ site_configuration = {
             'cxx': '',
             'ftn': '',
         },
-     ],
-     'logging': [
-        {
-            'level': 'debug',
-            'handlers': [
-                {
-                    'type': 'stream',
-                    'name': 'stdout',
-                    'level': 'info',
-                    'format': '%(message)s'
-                },
-                {
-                    'type': 'file',
-                    'prefix': f'{log_prefix}/reframe.log',
-                    'name': 'reframe.log',
-                    'level': 'debug',
-                    'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
-                    'append': True,
-                    'timestamp': "%Y%m%d_%H%M%S",
-                },
-            ],
-            'handlers_perflog': [
-                {
-                    'type': 'filelog',
-                    'prefix': f'{log_prefix}/%(check_system)s/%(check_partition)s',
-                    'level': 'info',
-                    'format': (
-                        '%(check_job_completion_time)s|reframe %(version)s|'
-                        '%(check_info)s|jobid=%(check_jobid)s|'
-                        '%(check_perf_var)s=%(check_perf_value)s|'
-                        'ref=%(check_perf_ref)s '
-                        '(l=%(check_perf_lower_thres)s, '
-                        'u=%(check_perf_upper_thres)s)|'
-                        '%(check_perf_unit)s'
-                    ),
-                    'append': True
-                }
-            ]
-        }
     ],
+    'logging': common_logging_config,
     'general': [
         {
             'remote_detect': True,
@@ -176,7 +133,7 @@ partition_defaults = {
     # However, using srun requires either using pmix or proper pmi2 integration in the MPI library
     # See https://github.com/EESSI/test-suite/pull/53#issuecomment-1598753968
     # Thus, we use mpirun for now, and manually swap to srun if we want to autodetect CPUs...
-    'launcher': 'srun',
+    'launcher': 'mpirun',
     'environs': ['default'],
     'features': [
         FEATURES['CPU']
@@ -191,5 +148,3 @@ partition_defaults = {
 for system in site_configuration['systems']:
     for partition in system['partitions']:
         partition.update(partition_defaults)
-
-

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -36,6 +36,7 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
+            'save_log_files': True,
         }
     ],
     'logging': common_logging_config,

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -1,6 +1,7 @@
 # ReFrame configuration file that can be used in GitHub Actions with EESSI
 
-from eessi.testsuite.constants import *
+from eessi.testsuite.common_config import common_logging_config
+from eessi.testsuite.constants import *  # noqa: F403
 
 
 site_configuration = {
@@ -38,40 +39,5 @@ site_configuration = {
             'keep_stage_files': True,
             }
         ],
-    'logging': [
-        {
-            'level': 'debug',
-            'handlers': [
-                {
-                    'type': 'stream',
-                    'name': 'stdout',
-                    'level': 'info',
-                    'format': '%(message)s'
-                    },
-                {
-                    'type': 'file',
-                    'level': 'debug',
-                    'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
-                    'append': True
-                    }
-                ],
-            'handlers_perflog': [
-                {
-                    'type': 'filelog',
-                    'prefix': '%(check_system)s/%(check_partition)s',
-                    'level': 'info',
-                    'format': (
-                        '%(check_job_completion_time)s|reframe %(version)s|'
-                        '%(check_info)s|jobid=%(check_jobid)s|'
-                        '%(check_perf_var)s=%(check_perf_value)s|'
-                        'ref=%(check_perf_ref)s '
-                        '(l=%(check_perf_lower_thres)s, '
-                        'u=%(check_perf_upper_thres)s)|'
-                        '%(check_perf_unit)s'
-                        ),
-                    'append': True
-                    }
-                ]
-            }
-        ],
+    'logging': common_logging_config,
 }

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -36,8 +36,7 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
-            'keep_stage_files': True,
-            }
-        ],
+        }
+    ],
     'logging': common_logging_config,
 }

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -36,8 +36,7 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
-            'save_log_files': True,
         }
     ],
-    'logging': common_logging_config,
+    'logging': common_logging_config(),
 }

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -1,16 +1,5 @@
-from os import environ, makedirs
-
-from eessi.testsuite.constants import *
-
-# Get username of current user
-homedir = environ.get('HOME')
-
-# This config will write all staging, output and logging to subdirs under this prefix
-reframe_prefix = f'{homedir}/reframe_runs'
-log_prefix = f'{reframe_prefix}/logs'
-
-# ReFrame complains if the directory for the file logger doesn't exist yet
-makedirs(f'{log_prefix}', exist_ok=True)
+from eessi.testsuite.common_config import common_logging_config
+from eessi.testsuite.constants import *  # noqa: F403
 
 # This is an example configuration file
 site_configuration = {
@@ -26,8 +15,7 @@ site_configuration = {
             'name': 'vega',
             'descr': 'Vega, a EuroHPC JU system',
             'modules_system': 'lmod',
-            'hostnames': ['vglogin*','cn*','gn*'],
-            'prefix': reframe_prefix,
+            'hostnames': ['vglogin*', 'cn*', 'gn*'],
             'partitions': [
                 {
                     'name': 'cpu',
@@ -97,46 +85,6 @@ site_configuration = {
             'cxx': '',
             'ftn': '',
         },
-     ],
-     'logging': [
-        {
-            'level': 'debug',
-            'handlers': [
-                {
-                    'type': 'stream',
-                    'name': 'stdout',
-                    'level': 'info',
-                    'format': '%(message)s'
-                },
-                {
-                    'type': 'file',
-                    'name': f'{log_prefix}/reframe.log',
-                    'level': 'debug',
-                    'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
-                    'append': True,
-                    'timestamp': "%Y%m%d_%H%M%S",
-                }
-            ],
-            'handlers_perflog': [
-                {
-                    'type': 'filelog',
-                    'prefix': f'{log_prefix}/%(check_system)s/%(check_partition)s',
-                    'level': 'info',
-                    'format': (
-                        '%(check_job_completion_time)s|reframe %(version)s|'
-                        '%(check_info)s|jobid=%(check_jobid)s|'
-                        '%(check_perfvalues)s'
-                    ),
-                    'format_perfvars': (
-                         '%(check_perf_var)s=%(check_perf_value)s|'
-                         'ref=%(check_perf_ref)s '
-                         '(l=%(check_perf_lower_thres)s, '
-                         'u=%(check_perf_upper_thres)s)|'
-                         '%(check_perf_unit)s|'
-                    ),
-                    'append': True
-                }
-            ]
-        }
     ],
+    'logging': common_logging_config,
 }

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -3,6 +3,10 @@ import os
 from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import *  # noqa: F403
 
+# This config will write all staging, output (and logging with --save-log-files) to subdirs under this prefix
+# Override with --prefix
+reframe_prefix = f'{os.environ.get("HOME")}/reframe_runs'
+
 # This is an example configuration file
 site_configuration = {
     'general': [
@@ -18,6 +22,7 @@ site_configuration = {
             'descr': 'Vega, a EuroHPC JU system',
             'modules_system': 'lmod',
             'hostnames': ['vglogin*', 'cn*', 'gn*'],
+            'prefix': reframe_prefix,
             'partitions': [
                 {
                     'name': 'cpu',
@@ -90,6 +95,3 @@ site_configuration = {
     ],
     'logging': common_logging_config,
 }
-
-# This config will write all staging, output and logging to subdirs under this prefix
-site_configuration['systems'][0]['prefix'] = f'{os.environ.get("HOME")}/reframe_runs'

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -3,9 +3,8 @@ import os
 from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import *  # noqa: F403
 
-# This config will write all staging, output (and logging with --save-log-files) to subdirs under this prefix
-# Override with --prefix
-reframe_prefix = f'{os.environ.get("HOME")}/reframe_runs'
+# This config will write all staging, output and logging to subdirs under this prefix
+reframe_prefix = os.path.join(os.environ['HOME'], 'reframe_runs')
 
 # This is an example configuration file
 site_configuration = {
@@ -14,7 +13,6 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-            'save_log_files': True,
         }
     ],
     'systems': [
@@ -94,5 +92,5 @@ site_configuration = {
             'ftn': '',
         },
     ],
-    'logging': common_logging_config,
+    'logging': common_logging_config(reframe_prefix),
 }

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -14,6 +14,7 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
+            'save_log_files': True,
         }
     ],
     'systems': [

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -1,3 +1,5 @@
+import os
+
 from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import *  # noqa: F403
 
@@ -75,9 +77,9 @@ site_configuration = {
                     ],
                     'descr': 'GPU partition, see https://en-doc.vega.izum.si/architecture/'
                 },
-             ]
-         },
-     ],
+            ]
+        },
+    ],
     'environments': [
         {
             'name': 'default',
@@ -88,3 +90,6 @@ site_configuration = {
     ],
     'logging': common_logging_config,
 }
+
+# This config will write all staging, output and logging to subdirs under this prefix
+site_configuration['systems'][0]['prefix'] = f'{os.environ.get("HOME")}/reframe_runs'

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -4,6 +4,7 @@ from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import *  # noqa: F403
 
 # This config will write all staging, output and logging to subdirs under this prefix
+# Override with RFM_PREFIX environment variable
 reframe_prefix = os.path.join(os.environ['HOME'], 'reframe_runs')
 
 # This is an example configuration file

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -78,10 +78,7 @@ site_configuration = {
             'ftn': '',
         },
     ],
-    'logging': common_logging_config,
-    'general': {
-        'save_log_files': True,  # copy ReFrame file logs to <prefix>/output on exit
-    },
+    'logging': common_logging_config(),
 }
 
 # optional logging to syslog

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -1,12 +1,11 @@
 """
 Example configuration file
 """
-from os import environ
+import os
 
-from eessi.testsuite.constants import *
+from eessi.testsuite.common_config import common_logging_config, format_perfvars, perflog_format
+from eessi.testsuite.constants import *  # noqa: F403
 
-
-username = environ.get('USER')
 
 site_configuration = {
     'systems': [
@@ -16,7 +15,7 @@ site_configuration = {
             'modules_system': 'lmod',
             'hostnames': ['*'],
             # Note that the stagedir should be a shared directory available on all nodes running ReFrame tests
-            'stagedir': f'/some/shared/dir/{username}/reframe_output/staging',
+            'stagedir': f'/some/shared/dir/{os.environ.get("USER")}/reframe_output/staging',
             'partitions': [
                 {
                     'name': 'cpu_partition',
@@ -79,42 +78,15 @@ site_configuration = {
             'ftn': '',
         },
     ],
-    'logging': [
-        {
-            'level': 'debug',
-            'handlers': [
-                {
-                    'type': 'stream',
-                    'name': 'stdout',
-                    'level': 'info',
-                    'format': '%(message)s'
-                },
-                {
-                    'type': 'file',
-                    'name': 'reframe.log',
-                    'level': 'debug',
-                    'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
-                    'append': True,
-                    'timestamp': "%Y%m%d_%H%M%S",
-                }
-            ],
-            'handlers_perflog': [
-                {
-                    'type': 'filelog',
-                    'prefix': '%(check_system)s/%(check_partition)s',
-                    'level': 'info',
-                    'format': (
-                        '%(check_job_completion_time)s|reframe %(version)s|'
-                        '%(check_info)s|jobid=%(check_jobid)s|'
-                        '%(check_perf_var)s=%(check_perf_value)s|'
-                        'ref=%(check_perf_ref)s '
-                        '(l=%(check_perf_lower_thres)s, '
-                        'u=%(check_perf_upper_thres)s)|'
-                        '%(check_perf_unit)s'
-                    ),
-                    'append': True
-                }
-            ]
-        }
-    ],
+    'logging': common_logging_config,
 }
+
+# optional logging to syslog
+site_configuration['logging'][0]['handlers_perflog'].append({
+    'type': 'syslog',
+    'address': '/dev/log',
+    'level': 'info',
+    'format': f'reframe: {perflog_format}',
+    'format_perfvars': format_perfvars,
+    'append': True,
+})

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -79,6 +79,9 @@ site_configuration = {
         },
     ],
     'logging': common_logging_config,
+    'general': {
+        'save_log_files': True,  # copy ReFrame file logs to <prefix>/output on exit
+    },
 }
 
 # optional logging to syslog

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -73,6 +73,7 @@ site_configuration = {
             # 1. The launchers to srun
             # 2. Add --exclusive to GPU 'access' field above (avoids submission error that no GPUs are requested)
             'remote_detect': True,
+            'save_log_files': True,
         }
     ],
 }

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -70,7 +70,7 @@ site_configuration = {
             'ftn': '',
         },
     ],
-    'logging': common_logging_config(),
+    'logging': common_logging_config(reframe_prefix),
     'general': [
         {
             # For autodetect to work, temporarily change:

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -1,9 +1,8 @@
-from os import environ
+import os
 
-from eessi.testsuite.constants import *
+from eessi.testsuite.common_config import common_logging_config
+from eessi.testsuite.constants import *  # noqa: F403
 
-
-username = environ.get('USER')
 
 # This is an example configuration file
 site_configuration = {
@@ -13,7 +12,7 @@ site_configuration = {
             'descr': 'Dutch National Supercomputer',
             'modules_system': 'lmod',
             'hostnames': ['int*', 'tcn*', 'hcn*', 'fcn*', 'gcn*', 'srv*'],
-            'stagedir': f'/scratch-shared/{username}/reframe_output/staging',
+            'stagedir': f'/scratch-shared/{os.environ.get("USER")}/reframe_output/staging',
             'partitions': [
                 {
                     'name': 'thin',
@@ -67,44 +66,7 @@ site_configuration = {
             'ftn': '',
         },
     ],
-    'logging': [
-        {
-            'level': 'debug',
-            'handlers': [
-                {
-                    'type': 'stream',
-                    'name': 'stdout',
-                    'level': 'info',
-                    'format': '%(message)s'
-                },
-                {
-                    'type': 'file',
-                    'name': 'reframe.log',
-                    'level': 'debug',
-                    'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
-                    'append': True,
-                    'timestamp': "%Y%m%d_%H%M%S",
-                }
-            ],
-            'handlers_perflog': [
-                {
-                    'type': 'filelog',
-                    'prefix': '%(check_system)s/%(check_partition)s',
-                    'level': 'info',
-                    'format': (
-                        '%(check_job_completion_time)s|reframe %(version)s|'
-                        '%(check_info)s|jobid=%(check_jobid)s|'
-                        '%(check_perf_var)s=%(check_perf_value)s|'
-                        'ref=%(check_perf_ref)s '
-                        '(l=%(check_perf_lower_thres)s, '
-                        'u=%(check_perf_upper_thres)s)|'
-                        '%(check_perf_unit)s'
-                    ),
-                    'append': True
-                }
-            ]
-        }
-    ],
+    'logging': common_logging_config,
     'general': [
         {
             # For autodetect to work, temporarily change:

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -3,9 +3,8 @@ import os
 from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import *  # noqa: F403
 
-# This config will write all staging, output (and logging with --save-log-files) to subdirs under this prefix
-# Override with --prefix
-reframe_prefix = f'{os.environ.get("HOME")}/reframe_runs'
+# This config will write all staging, output and logging to subdirs under this prefix
+reframe_prefix = os.path.join(os.environ['HOME'], 'reframe_runs')
 
 # This is an example configuration file
 site_configuration = {

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -66,14 +66,13 @@ site_configuration = {
             'ftn': '',
         },
     ],
-    'logging': common_logging_config,
+    'logging': common_logging_config(),
     'general': [
         {
             # For autodetect to work, temporarily change:
             # 1. The launchers to srun
             # 2. Add --exclusive to GPU 'access' field above (avoids submission error that no GPUs are requested)
             'remote_detect': True,
-            'save_log_files': True,
         }
     ],
 }

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -4,6 +4,7 @@ from eessi.testsuite.common_config import common_logging_config
 from eessi.testsuite.constants import *  # noqa: F403
 
 # This config will write all staging, output and logging to subdirs under this prefix
+# Override with RFM_PREFIX environment variable
 reframe_prefix = os.path.join(os.environ['HOME'], 'reframe_runs')
 
 # This is an example configuration file

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -195,8 +195,7 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
-            'save_log_files': True,
         }
     ],
-    'logging': common_logging_config,
+    'logging': common_logging_config(),
 }

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -41,6 +41,7 @@ site_configuration = {
                         'num_cpus': 128,
                         'num_sockets': 2,
                         'num_cpus_per_socket': 64,
+                        'num_cpus_per_core': 1,
                         'arch': 'zen2',
                     },
                     'features': [
@@ -60,6 +61,7 @@ site_configuration = {
                         'num_cpus': 128,
                         'num_sockets': 2,
                         'num_cpus_per_socket': 64,
+                        'num_cpus_per_core': 1,
                         'arch': 'zen2',
                     },
                     'features': [
@@ -79,6 +81,7 @@ site_configuration = {
                         'num_cpus': 128,
                         'num_sockets': 2,
                         'num_cpus_per_socket': 64,
+                        'num_cpus_per_core': 1,
                         'arch': 'zen3',
                     },
                     'features': [
@@ -98,6 +101,7 @@ site_configuration = {
                         'num_cpus': 48,
                         'num_sockets': 2,
                         'num_cpus_per_socket': 24,
+                        'num_cpus_per_core': 1,
                         'arch': 'zen2',
                     },
                     'features': [
@@ -133,6 +137,7 @@ site_configuration = {
                         'num_cpus': 48,
                         'num_sockets': 2,
                         'num_cpus_per_socket': 24,
+                        'num_cpus_per_core': 1,
                         'arch': 'zen2',
                     },
                     'features': [
@@ -190,7 +195,6 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
-            'keep_stage_files': True,
         }
     ],
     'logging': common_logging_config,

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -1,39 +1,15 @@
 # ReFrame configuration file for VSC Tier-1 Hortense
 # https://docs.vscentrum.be/en/latest/gent/tier1_hortense.html
 #
-# authors: Sam Moors (VUB-HPC), Kenneth Hoste (HPC-UGent)
+# authors: Samuel Moors (VUB-HPC), Kenneth Hoste (HPC-UGent)
 
 from reframe.core.backends import register_launcher
 from reframe.core.launchers import JobLauncher
 
-from eessi.testsuite.constants import *
-
+from eessi.testsuite.common_config import common_logging_config
+from eessi.testsuite.constants import *  # noqa: F403
 
 account = "my-slurm-account"
-
-# use 'info' to log to syslog
-syslog_level = 'warning'
-
-perf_logging_format = 'reframe: ' + '|'.join([
-    'username=%(osuser)s',
-    'version=%(version)s',
-    'name=%(check_name)s',
-    'system=%(check_system)s',
-    'partition=%(check_partition)s',
-    'environ=%(check_environ)s',
-    'num_tasks=%(check_num_tasks)s',
-    'num_cpus_per_task=%(check_num_cpus_per_task)s',
-    'num_tasks_per_node=%(check_num_tasks_per_node)s',
-    'modules=%(check_modules)s',
-    'jobid=%(check_jobid)s',
-    '%(check_perfvalues)s',
-])
-
-format_perfvars = '|'.join([
-    'perf_var=%(check_perf_var)s',
-    'perf_value=%(check_perf_value)s',
-    'unit=%(check_perf_unit)s',
-]) + '|'
 
 hortense_access = [f'-A {account}', '--export=NONE', '--get-user-env=60L']
 
@@ -41,7 +17,7 @@ hortense_access = [f'-A {account}', '--export=NONE', '--get-user-env=60L']
 @register_launcher('mympirun')
 class MyMpirunLauncher(JobLauncher):
     def command(self, job):
-        return ['mympirun', '--hybrid', str(job.num_tasks)]
+        return ['mympirun', '--hybrid', str(job.num_tasks_per_node)]
 
 
 site_configuration = {
@@ -217,51 +193,5 @@ site_configuration = {
             'keep_stage_files': True,
         }
     ],
-    'logging': [
-        {
-            'level': 'debug',
-            'handlers': [
-                {
-                    'type': 'file',
-                    'name': 'reframe.log',
-                    'level': 'debug',
-                    'format': '[%(asctime)s] %(levelname)s: %(check_name)s: %(message)s',  # noqa: E501
-                    'append': True,
-                    'timestamp': "%Y%m%d_%H%M%S",
-                },
-                {
-                    'type': 'stream',
-                    'name': 'stdout',
-                    'level': 'info',
-                    'format': '%(message)s',
-                },
-                {
-                    'type': 'file',
-                    'name': 'reframe.out',
-                    'level': 'info',
-                    'format': '%(message)s',
-                    'append': True,
-                    'timestamp': "%Y%m%d_%H%M%S",
-                },
-            ],
-            'handlers_perflog': [
-                {
-                    'type': 'filelog',
-                    'prefix': '%(check_system)s/%(check_partition)s',
-                    'level': 'info',
-                    'format': '%(check_job_completion_time)s ' + perf_logging_format,
-                    'format_perfvars': format_perfvars,
-                    'append': True,
-                },
-                {
-                    'type': 'syslog',
-                    'address': '/dev/log',
-                    'level': syslog_level,
-                    'format': perf_logging_format,
-                    'format_perfvars': format_perfvars,
-                    'append': True,
-                },
-            ],
-        }
-    ],
+    'logging': common_logging_config,
 }

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -195,6 +195,7 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
+            'save_log_files': True,
         }
     ],
     'logging': common_logging_config,

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -1,3 +1,5 @@
+import os
+
 perflog_format = '|'.join([
     '%(check_job_completion_time)s',
     '%(osuser)s',
@@ -27,32 +29,42 @@ format_perfvars = '|'.join([
     ''  # final delimiter required
 ])
 
-common_logging_config = [{
-    'level': 'debug',
-    'handlers': [
-        {
-            'type': 'stream',
-            'name': 'stdout',
-            'level': 'info',
-            'format': '%(message)s',
-        },
-        {
-            'type': 'file',
-            'name': 'reframe.log',
-            'level': 'debug',
-            'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',
-            'append': True,
-            'timestamp': "%Y%m%d_%H%M%S",  # add a timestamp to the filename (reframe_<timestamp>.log)
-        },
-    ],
-    'handlers_perflog': [
-        {
-            'type': 'filelog',
-            'prefix': '%(check_system)s/%(check_partition)s',
-            'level': 'info',
-            'format': perflog_format,
-            'format_perfvars': format_perfvars,
-            'append': True,  # avoid overwriting
-        },
-    ],
-}]
+
+def common_logging_config(prefix=None):
+    """
+    return default logging configuration as a list: stdout, file log, perflog
+    :param prefix: file log prefix
+    """
+    prefix = os.getenv('RFM_PREFIX', prefix if prefix else '.')
+
+    os.makedirs(os.path.join(prefix, 'log'), exist_ok=True)
+
+    return [{
+        'level': 'debug',
+        'handlers': [
+            {
+                'type': 'stream',
+                'name': 'stdout',
+                'level': 'info',
+                'format': '%(message)s',
+            },
+            {
+                'type': 'file',
+                'name': os.path.join(prefix, 'log', 'reframe.log'),
+                'level': 'debug',
+                'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',
+                'append': True,
+                'timestamp': "%Y%m%d_%H%M%S",  # add a timestamp to the filename (reframe_<timestamp>.log)
+            },
+        ],
+        'handlers_perflog': [
+            {
+                'type': 'filelog',
+                'prefix': '%(check_system)s/%(check_partition)s',
+                'level': 'info',
+                'format': perflog_format,
+                'format_perfvars': format_perfvars,
+                'append': True,  # avoid overwriting
+            },
+        ],
+    }]

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -36,8 +36,8 @@ def common_logging_config(prefix=None):
     :param prefix: file log prefix
     """
     prefix = os.getenv('RFM_PREFIX', prefix if prefix else '.')
-
-    os.makedirs(os.path.join(prefix, 'log'), exist_ok=True)
+    logdir = os.path.join(prefix, 'logs')
+    os.makedirs(logdir, exist_ok=True)
 
     return [{
         'level': 'debug',
@@ -50,7 +50,7 @@ def common_logging_config(prefix=None):
             },
             {
                 'type': 'file',
-                'name': os.path.join(prefix, 'log', 'reframe.log'),
+                'name': os.path.join(logdir, 'reframe.log'),
                 'level': 'debug',
                 'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',
                 'append': True,

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -1,0 +1,58 @@
+perflog_format = '|'.join([
+    '%(check_job_completion_time)s',
+    '%(osuser)s',
+    '%(version)s',
+    '%(check_unique_name)s',
+    '%(check_info)s',
+    '%(check_system)s',
+    '%(check_partition)s',
+    '%(check_environ)s',
+    '%(check_exclusive_access)s',
+    '%(check_num_tasks)s',
+    '%(check_num_cpus_per_task)s',
+    '%(check_num_tasks_per_node)s',
+    '%(check_num_gpus_per_node)s',
+    '%(check_use_multithreading)s',
+    '%(check_modules)s',
+    '%(check_jobid)s',
+    '%(check_perfvalues)s',
+])
+
+format_perfvars = '|'.join([
+    '%(check_perf_var)s',
+    '%(check_perf_value)s',
+    '%(check_perf_lower_thres)s',
+    '%(check_perf_upper_thres)s',
+    '%(check_perf_unit)s',
+    ''  # final delimiter required
+])
+
+common_logging_config = [{
+    'level': 'debug',
+    'handlers': [
+        {
+            'type': 'stream',
+            'name': 'stdout',
+            'level': 'info',
+            'format': '%(message)s',
+        },
+        {
+            'type': 'file',
+            'name': 'reframe.log',
+            'level': 'debug',
+            'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',
+            'append': True,
+            'timestamp': "%Y%m%d_%H%M%S",  # add a timestamp to the filename (reframe_<timestamp>.log)
+        },
+    ],
+    'handlers_perflog': [
+        {
+            'type': 'filelog',
+            'prefix': '%(check_system)s/%(check_partition)s',
+            'level': 'info',
+            'format': perflog_format,
+            'format_perfvars': format_perfvars,
+            'append': True,  # avoid overwriting
+        },
+    ],
+}]

--- a/scripts/run_reframe.sh
+++ b/scripts/run_reframe.sh
@@ -51,7 +51,6 @@ options=(
     --tag CI ${TAGS}
     --run
     --performance-report
-    --save-log-files  # copy ReFrame file logs to <prefix>/output on exit
 )
 reframe "${options[@]}"
 

--- a/scripts/run_reframe.sh
+++ b/scripts/run_reframe.sh
@@ -42,9 +42,22 @@ source /cvmfs/pilot.eessi-hpc.org/latest/init/bash
 deactivate
 source ${TEMPDIR}/${REFRAME_VENV}/bin/activate
 
+# save dirs stage, output, perflogs into PREFIX
+PREFIX=$HOME/reframe_runs
+
 # Run ReFrame
 echo "PYTHONPATH: ${PYTHONPATH}"
-reframe -C ${TEMPDIR}/test-suite/config/${RFM_CONFIG_NAME} -c ${TEMPDIR}/test-suite/eessi/testsuite/tests/apps/ -R -t CI ${TAGS} -r --performance-report
+options=(
+    --config-file ${TEMPDIR}/test-suite/config/${RFM_CONFIG_NAME}
+    --checkpath ${TEMPDIR}/test-suite/eessi/testsuite/tests/apps/
+    --recursive  # Search for checks in the search path recursively
+    --tag CI ${TAGS}
+    --run
+    --performance-report
+    --prefix $PREFIX
+    --save-log-files  # copy ReFrame file logs to $PREFIX/output on exit
+)
+reframe "${options[@]}"
 
 # Cleanup
 rm -rf ${TEMPDIR}

--- a/scripts/run_reframe.sh
+++ b/scripts/run_reframe.sh
@@ -42,9 +42,6 @@ source /cvmfs/pilot.eessi-hpc.org/latest/init/bash
 deactivate
 source ${TEMPDIR}/${REFRAME_VENV}/bin/activate
 
-# save dirs stage, output, perflogs into PREFIX
-PREFIX=$HOME/reframe_runs
-
 # Run ReFrame
 echo "PYTHONPATH: ${PYTHONPATH}"
 options=(
@@ -54,8 +51,7 @@ options=(
     --tag CI ${TAGS}
     --run
     --performance-report
-    --prefix $PREFIX
-    --save-log-files  # copy ReFrame file logs to $PREFIX/output on exit
+    --save-log-files  # copy ReFrame file logs to <prefix>/output on exit
 )
 reframe "${options[@]}"
 


### PR DESCRIPTION
changes in this PR:
- use common config section for logging
- fix mympirun launcher for hortense
- ~use reframe options `--prefix` and `--save-log-files` to make sure **all** output goes into the prefix~
- support overriding the prefix for file logs with `RFM_PREFIX`

fixes https://github.com/EESSI/test-suite/issues/64
fixes https://github.com/EESSI/test-suite/issues/61