### PR TITLE
Improve find_modules with regex functionality

### DIFF
--- a/eessi/testsuite/utils.py
+++ b/eessi/testsuite/utils.py
@@ -4,7 +4,7 @@ Utility functions for ReFrame tests
 
 import re
 import sys
-from typing import Iterator
+from typing import Iterator, List
 
 import reframe as rfm
 import reframe.core.runtime as rt
@@ -57,15 +57,58 @@ def is_cuda_required_module(module_name: str) -> bool:
     return requires_cuda
 
 
-def find_modules(substr: str) -> Iterator[str]:
-    """Return all modules in the current system that contain ``substr`` in their name."""
-    if not isinstance(substr, str):
+def find_modules(regex: str, name_only = True) -> Iterator[str]:
+    """
+    Return all modules matching the regular expression regex. Note that since we use re.search,
+    a module matches if the regex matches the module name at any place. I.e. the match does
+    not have to be at the start of the smodule name
+    
+    Arguments:
+    - regex: a regular expresion
+    - name_only: regular expressions will only be matched on the module name, not the version (default: True).
+    
+    Note: the name_only feature assumes anything after the last forward '/' is the version,
+    and strips that before doing a match.
+
+    Example
+
+    Suppose we have the following modules on a system:
+
+    gompic/2022a
+    gompi/2022a
+    CGAL/4.14.3-gompi-2022a
+
+    The following calls would return the following respective modules
+
+    find_modules('gompi') => [gompic/2022a, gompi/2022a]
+    find_modules('gompi$') => [gompi/2022a]
+    find_modules('gompi', name_only = False) => [gompic/2022a, gompi/2022a, CGAL/4.14.3-gompi-2022a]
+    find_modules('^gompi', name_only = False) => [gompic/2022a, gompi/2022a]
+    find_modules('^gompi\/', name_only = False) => [gompi/2022a]
+    find_modules('-gompi-2022a', name_only = False) => [CGAL/4.14.3-gompi-2022a]
+
+    """
+
+    if not isinstance(regex, str):
         raise TypeError("'substr' argument must be a string")
 
     ms = rt.runtime().modules_system
-    modules = OrderedSet(ms.available_modules(substr))
-    for m in modules:
-        yield m
+    # Returns e.g. ['Bison/', 'Bison/3.7.6-GCCcore-10.3.0', 'BLIS/', 'BLIS/0.8.1-GCC-10.3.0']
+    modules = ms.available_modules('')
+    for mod in modules:
+        # Exclude anything without version, i.e. ending with / (e.g. Bison/)
+        if re.search('.*\/$', mod):
+            continue
+        # The thing we yield should always be the original module name (orig_mod), including version
+        orig_mod = mod
+        if name_only:
+            # Remove part after the last forward slash, as we assume this is the version
+            mod = re.sub('\/[^\/]*$', '', mod)
+        # Match the actual regular expression
+        log(f"Matching module {mod} with regex {regex}")
+        if re.search(regex, mod):
+            log(f"Match!")
+            yield orig_mod
 
 def check_proc_attribute_defined(test: rfm.RegressionTest, attribute) -> bool:
     """

--- a/eessi/testsuite/utils.py
+++ b/eessi/testsuite/utils.py
@@ -102,6 +102,8 @@ def find_modules(regex: str, name_only = True) -> Iterator[str]:
         # The thing we yield should always be the original module name (orig_mod), including version
         orig_mod = mod
         if name_only:
+            # Remove trailing slashes from the regex (in case the callee forgot)
+            regex = regex.rstrip('/')
             # Remove part after the last forward slash, as we assume this is the version
             mod = re.sub('\/[^\/]*$', '', mod)
         # Match the actual regular expression

--- a/eessi/testsuite/utils.py
+++ b/eessi/testsuite/utils.py
@@ -4,7 +4,7 @@ Utility functions for ReFrame tests
 
 import re
 import sys
-from typing import Iterator, List
+from typing import Iterator
 
 import reframe as rfm
 import reframe.core.runtime as rt


### PR DESCRIPTION
Expand functionality of find_modules so that it can be passed a regular expression. It can also ommit the version (i.e. anything after the last slash) from the match, if required.

If you want to define a ReFrame test to play around with the new `find_modules` functionality:

```
# eessi/tests/find_modules.py
import reframe as rfm
import reframe.utility.sanity as sn

from eessi.testsuite import hooks, utils
from eessi.testsuite.constants import *

@rfm.simple_test
class find_modules(rfm.RunOnlyRegressionTest):

    # This test can run at any scale, so parameterize over all known SCALES
    valid_prog_environs = ['default']
    valid_systems = ['*']

    # Parameterize over all modules that start with X
    module_name = parameter(utils.find_modules('^gompi\/', name_only = False))

    executable = 'hostname'

    time_limit = '5m'

    # This test should be run as part of EESSI CI
    tags = {TAGS['CI']}
```
Then run with e.g. 
```
reframe -C test-suite/config/izum_vega.py -c test-suite/eessi/testsuite/tests/find_modules.py -R -t CI -l
```

This also makes me think: do we need unittests for the test suite? I.e. tests that test the `hooks` & `utils`?  It might be difficult to make some of those, e.g. how do we convince the ReFrame runtimes `available_modules` to return us a predetermined set of modules? But it would be worthwhile to have, as it defines the desired behaviour. It would also be very valuable for things like: does filtering work (which tests should run on which partitions), how many MPI ranks & OpenMP threads are launched, etc.