### PR TITLE
add content type of long description + license to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,9 @@
 name = eessi-testsuite
 version = 0.1.0
 description = Test suite for the EESSI software stack
-long_description = file: README.md, LICENSE
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = GPL-2.0-only
 classifiers =
     Programming Language :: Python :: 3
 project_urls =


### PR DESCRIPTION
This was necessary to publish v0.1.0 to PyPI: https://pypi.org/project/eessi-testsuite/0.1.0