### PR TITLE
add hook to assign tasks per node

### DIFF
--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -9,6 +9,7 @@ CPU_SOCKET = 'CPU_SOCKET'
 GPU = 'GPU'
 GPU_VENDOR = 'GPU_VENDOR'
 INTEL = 'INTEL'
+NODE = 'NODE'
 NVIDIA = 'NVIDIA'
 
 DEVICE_TYPES = {
@@ -20,6 +21,7 @@ COMPUTE_UNIT = {
     CPU: 'cpu',
     CPU_SOCKET: 'cpu_socket',
     GPU: 'gpu',
+    NODE: 'node',
 }
 
 TAGS = {

--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -89,7 +89,7 @@ class GROMACS_EESSI(gromacs_check):
         # Calculate default requested resources based on the scale:
         # 1 task per CPU for CPU-only tests, 1 task per GPU for GPU tests.
         # Also support setting the resources on the cmd line.
-        hooks.assign_one_task_per_compute_unit(test=self, compute_unit=self.nb_impl)
+        hooks.assign_tasks_per_compute_unit(test=self, compute_unit=self.nb_impl)
 
     @run_after('setup')
     def set_omp_num_threads(self):


### PR DESCRIPTION
- add hook ` _assign_num_tasks_per_node` which can be used in the OSU benchmark
- rename hook `assign_one_task_per_compute_unit` to `assign_tasks_per_compute_unit`, to reflect that more than 1 task can be requested per compute unit (currently only implemented for ` _assign_num_tasks_per_node`)
