### PR TITLE
use latest version of `eessi/github-action-eessi`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         EESSI_VERSION:
-        - "2021.12"
+        - "2023.06"
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -31,11 +31,11 @@ jobs:
             export EASYBUILD_PREFIX=$HOME/easybuild
             # need to force module generation with --module-only --force because 'pip check' fails
             # in EESSI pilot 2021.12, see https://github.com/EESSI/compatibility-layer/issues/152
-            eb ReFrame-4.2.0.eb || eb ReFrame-4.2.0.eb --module-only --force
+            eb ReFrame-4.3.3.eb || eb ReFrame-4.3.3.eb --module-only --force
 
             # load ReFrame
             module use $HOME/easybuild/modules/all
-            module load ReFrame/4.2.0
+            module load ReFrame/4.3.3
             reframe --version
 
             # configure ReFrame (cfr. https://reframe-hpc.readthedocs.io/en/stable/manpage.html#environment)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             persist-credentials: false
 
         - name: Mount EESSI CernVM-FS pilot repository
-          uses: eessi/github-action-eessi@58b50fd2eead2162c2b9ac258d4fb60cc9f30503  # v2.0.13
+          uses: eessi/github-action-eessi@e1f8f20638ea417a18d23ab29443ee34794ff900  # v3.1.0
           with:
             eessi_stack_version: ${{matrix.EESSI_VERSION}}
 


### PR DESCRIPTION
will fix:

```
Error: Bad request - cvmfs-contrib/github-action-cvmfs@d4641d0d591c9a5c3be23835ced2fb648b44c04b is not allowed to be used in EESSI/test-suite
```

see also https://github.com/EESSI/github-action-eessi/pull/22