### PR TITLE
use venv rather than 'pip install --user' in CI workflow to test test suite

### DIFF
--- a/.github/workflows/pip_install.yml
+++ b/.github/workflows/pip_install.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
-        - name: Check out software-layer repository
-          uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        - name: Check out repository
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
           with:
             persist-credentials: false
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         - "2023.06"
     steps:
         - name: Check out software-layer repository
-          uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
           with:
             persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
           run: |
             # install latest version of EasyBuild, to install ReFrame with it,
             # since that includes the ReFrame test library (hpctestlib) that we rely on
-            pip3 install --user easybuild
-            export PATH=$HOME/.local/bin:$PATH
+            python3 -m venv venv
+            source venv/bin/activate
+            pip3 install easybuild
             eb --version
             export EASYBUILD_PREFIX=$HOME/easybuild
             # need to force module generation with --module-only --force because 'pip check' fails


### PR DESCRIPTION
fix for
```
error: externally-managed-environment

× This environment is externally managed
╰─> 
    The system-wide Python installation in Gentoo should be maintained
    using the system package manager (e.g. emerge).
    
    If the package in question is not packaged for Gentoo, please
    consider installing it inside a virtual environment, e.g.:
    
    python -m venv /path/to/venv
    . /path/to/venv/bin/activate
    pip install mypackage
    
    To exit the virtual environment, run:
    
    deactivate
    
    The virtual environment is not deleted, and can be re-entered by
    re-sourcing the activate file.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```