### PR TITLE
use EESSI pilot repo for testing test suite (for now)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         EESSI_VERSION:
-        - "2021.12"
+        - "2023.06"
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -27,7 +27,7 @@ jobs:
           run: |
             source /cvmfs/pilot.eessi-hpc.org/versions/${{matrix.EESSI_VERSION}}/init/bash
 
-            module load ReFrame/4.2.0
+            module load ReFrame/4.3.3
             reframe --version
 
             # configure ReFrame (cfr. https://reframe-hpc.readthedocs.io/en/stable/manpage.html#environment)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,11 @@ jobs:
             persist-credentials: false
 
         - name: Mount EESSI CernVM-FS pilot repository
-          uses: eessi/github-action-eessi@e1f8f20638ea417a18d23ab29443ee34794ff900  # v3.1.0
+          uses: cvmfs-contrib/github-action-cvmfs@55899ca74cf78ab874bdf47f5a804e47c198743c # v4.0
           with:
-            eessi_stack_version: ${{matrix.EESSI_VERSION}}
+              cvmfs_config_package: https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb
+              cvmfs_http_proxy: DIRECT
+              cvmfs_repositories: pilot.eessi-hpc.org
 
         - name: Run test suite
           run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         EESSI_VERSION:
-        - "2023.06"
+        - "2021.12"
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -25,20 +25,9 @@ jobs:
 
         - name: Run test suite
           run: |
-            # install latest version of EasyBuild, to install ReFrame with it,
-            # since that includes the ReFrame test library (hpctestlib) that we rely on
-            python3 -m venv venv
-            source venv/bin/activate
-            pip3 install easybuild
-            eb --version
-            export EASYBUILD_PREFIX=$HOME/easybuild
-            # need to force module generation with --module-only --force because 'pip check' fails
-            # in EESSI pilot 2021.12, see https://github.com/EESSI/compatibility-layer/issues/152
-            eb ReFrame-4.3.3.eb || eb ReFrame-4.3.3.eb --module-only --force
+            source /cvmfs/pilot.eessi-hpc.org/versions/${{matrix.EESSI_VERSION}}/init/bash
 
-            # load ReFrame
-            module use $HOME/easybuild/modules/all
-            module load ReFrame/4.3.3
+            module load ReFrame/4.2.0
             reframe --version
 
             # configure ReFrame (cfr. https://reframe-hpc.readthedocs.io/en/stable/manpage.html#environment)


### PR DESCRIPTION
Fix for indirect switch to `software.eessi.io` in #102

We have to keep using the EESSI pilot repo for now, since `software.eessi.io` does not provide GROMACS yet (cfr. https://github.com/EESSI/software-layer/pull/401)