### PR TITLE
unify test names: `EESSI_` + software name (with '`-`' replaced by '`_`') + optional label for type of test

### DIFF
--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -39,7 +39,7 @@ from eessi.testsuite.utils import find_modules, log
 
 
 @rfm.simple_test
-class GROMACS_EESSI(gromacs_check):
+class EESSI_GROMACS(gromacs_check):
     scale = parameter(SCALES.keys())
     valid_prog_environs = ['default']
     valid_systems = []

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -38,7 +38,7 @@ def filter_scales_coll():
 
 
 @rfm.simple_test
-class osu_pt_2_pt(osu_benchmark):
+class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
     ''' Run-only OSU test '''
     scale = parameter(filter_scales_pt2pt())
     valid_prog_environs = ['default']
@@ -154,7 +154,7 @@ class osu_pt_2_pt(osu_benchmark):
 
 
 @rfm.simple_test
-class osu_coll(osu_benchmark):
+class EESSI_OSU_Micro_Benchmarks_coll(osu_benchmark):
     ''' Run-only OSU test '''
     scale = parameter(filter_scales_coll())
     valid_prog_environs = ['default']

--- a/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
+++ b/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
@@ -11,7 +11,7 @@ from eessi.testsuite import hooks, utils
 from eessi.testsuite.constants import *  # noqa
 
 @rfm.simple_test
-class TENSORFLOW_EESSI(rfm.RunOnlyRegressionTest):
+class EESSI_TensorFlow(rfm.RunOnlyRegressionTest):
 
     # This test can run at any scale, so parameterize over all known SCALES
     scale = parameter(SCALES.keys())


### PR DESCRIPTION
As far as I can tell, there's no way to tweak the test name, it's always determined by the Python class name (see https://reframe-hpc.readthedocs.io/en/stable/manpage.html#test-naming-scheme)

Before these changes (with EESSI pilot 2021.12 as available modules):

```
$ reframe --list --system hortense:cpu_rome_256gb --tag CI --tag 2_cores
...
[List of matched checks]
- GROMACS_EESSI %benchmark_info=HECBioSim/Crambin %nb_impl=cpu %scale=2_cores %module_name=GROMACS/2020.4-foss-2020a-Python-3.8.2 /1d77cf1a
- GROMACS_EESSI %benchmark_info=HECBioSim/Crambin %nb_impl=cpu %scale=2_cores %module_name=GROMACS/2020.1-foss-2020a-Python-3.8.2 /9857398f
- osu_coll %benchmark_info=mpi.collective.osu_allreduce %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.7.1-gompi-2021a %device_type=cpu /82cca1df
- osu_coll %benchmark_info=mpi.collective.osu_allreduce %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.6.3-gompi-2020a %device_type=cpu /180c80da
- osu_coll %benchmark_info=mpi.collective.osu_alltoall %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.7.1-gompi-2021a %device_type=cpu /890c65c1
- osu_coll %benchmark_info=mpi.collective.osu_alltoall %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.6.3-gompi-2020a %device_type=cpu /62da5e4a
- osu_pt_2_pt %benchmark_info=mpi.pt2pt.osu_latency %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.7.1-gompi-2021a %device_type=cpu /691d7eb9
- osu_pt_2_pt %benchmark_info=mpi.pt2pt.osu_latency %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.6.3-gompi-2020a %device_type=cpu /a714d15e
- osu_pt_2_pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.7.1-gompi-2021a %device_type=cpu /a1999431
- osu_pt_2_pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.6.3-gompi-2020a %device_type=cpu /80b32ca6
- TENSORFLOW_EESSI %scale=2_cores %module_name=TensorFlow/2.3.1-foss-2020a-Python-3.8.2 %device_type=cpu /7b478c18
Found 11 check(s)
```

With these changes:

```
$ reframe --list --system hortense:cpu_rome_256gb --tag CI --tag 2_cores
...
[List of matched checks]
- EESSI_GROMACS %benchmark_info=HECBioSim/Crambin %nb_impl=cpu %scale=2_cores %module_name=GROMACS/2020.4-foss-2020a-Python-3.8.2 /609972e8
- EESSI_GROMACS %benchmark_info=HECBioSim/Crambin %nb_impl=cpu %scale=2_cores %module_name=GROMACS/2020.1-foss-2020a-Python-3.8.2 /4c5c9c39
- EESSI_OSU_Micro_Benchmarks_coll %benchmark_info=mpi.collective.osu_allreduce %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.7.1-gompi-2021a %device_type=cpu /b0ba2f19
- EESSI_OSU_Micro_Benchmarks_coll %benchmark_info=mpi.collective.osu_allreduce %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.6.3-gompi-2020a %device_type=cpu /5b97a275
- EESSI_OSU_Micro_Benchmarks_coll %benchmark_info=mpi.collective.osu_alltoall %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.7.1-gompi-2021a %device_type=cpu /0eb2c6b1
- EESSI_OSU_Micro_Benchmarks_coll %benchmark_info=mpi.collective.osu_alltoall %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.6.3-gompi-2020a %device_type=cpu /aa437fd4
- EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_latency %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.7.1-gompi-2021a %device_type=cpu /e39fe386
- EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_latency %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.6.3-gompi-2020a %device_type=cpu /5d5bb92f
- EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.7.1-gompi-2021a %device_type=cpu /197f6650
- EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_cores %module_name=OSU-Micro-Benchmarks/5.6.3-gompi-2020a %device_type=cpu /98f3df8a
- EESSI_TensorFlow %scale=2_cores %module_name=TensorFlow/2.3.1-foss-2020a-Python-3.8.2 %device_type=cpu /a640020c
Found 11 check(s)
```