### PR TITLE
do not run cuda modules on non-gpu partitions

### DIFF
--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -299,10 +299,14 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
         # GPU_VENDOR=GPU_VENDORS[NVIDIA] extras
         valid_systems = f'+{FEATURES[GPU]} %{GPU_VENDOR}={GPU_VENDORS[NVIDIA]}'
 
-    elif required_device_type == DEVICE_TYPES[CPU]:
+    elif not is_cuda_module and required_device_type == DEVICE_TYPES[CPU]:
         # Using the CPU requires partitions with FEATURES[CPU] feature
         # Note: making FEATURES[CPU] an explicit feature allows e.g. skipping CPU-based tests on GPU partitions
         valid_systems = f'+{FEATURES[CPU]}'
+
+    elif is_cuda_module and required_device_type == DEVICE_TYPES[CPU]:
+        # Note: This applies for CUDA module tests that want to test only on cpus on gpu partitions.
+        valid_systems = f'+{FEATURES[CPU]} +{FEATURES[GPU]} %{GPU_VENDOR}={GPU_VENDORS[NVIDIA]}'
 
     elif not is_cuda_module and required_device_type == DEVICE_TYPES[GPU]:
         # Invalid combination: a module without GPU support cannot use a GPU

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -50,13 +50,13 @@ class osu_pt_2_pt(osu_benchmark):
     device_type = parameter([DEVICE_TYPES[CPU], DEVICE_TYPES[GPU]])
     # unset num_tasks_per_node from the hpctestlib.
     num_tasks_per_node = None
-    # Note: device_buffers variable is inherited from the hpctestlib class and adds options to the launcher
-    # commands based on what device is set.
-    device_buffers = 'cpu'
 
     @run_after('init')
     def run_after_init(self):
         """hooks to run after init phase"""
+        # Note: device_buffers variable is inherited from the hpctestlib class and adds options to the launcher
+        # commands based on what device is set.
+        self.device_buffers = 'cpu'
         hooks.filter_valid_systems_by_device_type(self, required_device_type=self.device_type)
         is_cuda_module = utils.is_cuda_required_module(self.module_name)
         # This part of the hook is meant to be for the OSU cpu tests. This is required since the non CUDA module should
@@ -111,14 +111,6 @@ class osu_pt_2_pt(osu_benchmark):
         hooks.set_tag_scale(self)
 
     @run_after('setup')
-    def set_environment(self):
-        """ Setting environment variable for CUDA module tests that run on pure cpu nodes."""
-        is_cuda_module = utils.is_cuda_required_module(self.module_name)
-        if (is_cuda_module and self.device_type == DEVICE_TYPES[CPU] and
-                (not FEATURES[GPU] in self.current_partition.features)):
-            self.env_vars = {'LD_LIBRARY_PATH': '$EBROOTCUDA/stubs/lib64:$LD_LIBRARY_PATH'}
-
-    @run_after('setup')
     def set_num_tasks_per_node(self):
         """ Setting number of tasks per node and cpus per task in this function. This function sets num_cpus_per_task
         for 1 node and 2 node options where the request is for full nodes."""
@@ -171,6 +163,9 @@ class osu_coll(osu_benchmark):
     @run_after('init')
     def run_after_init(self):
         """hooks to run after init phase"""
+        # Note: device_buffers variable is inherited from the hpctestlib class and adds options to the launcher
+        # commands based on what device is set.
+        self.device_buffers = 'cpu'
         hooks.filter_valid_systems_by_device_type( self, required_device_type=self.device_type)
         is_cuda_module = utils.is_cuda_required_module(self.module_name)
         if is_cuda_module and self.device_type == DEVICE_TYPES[GPU]:
@@ -209,14 +204,6 @@ class osu_coll(osu_benchmark):
     @run_after('init')
     def set_num_tasks(self):
         hooks.set_tag_scale(self)
-
-    @run_after('setup')
-    def set_environment(self):
-        """ Setting environment variable for CUDA module tests that run on pure cpu nodes."""
-        is_cuda_module = utils.is_cuda_required_module(self.module_name)
-        if (is_cuda_module and self.device_type == DEVICE_TYPES[CPU] and
-                (not FEATURES[GPU] in self.current_partition.features)):
-            self.env_vars = {'LD_LIBRARY_PATH': '$EBROOTCUDA/stubs/lib64:$LD_LIBRARY_PATH'}
 
     @run_after('setup')
     def set_num_tasks_per_node(self):

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -55,7 +55,7 @@ class osu_pt_2_pt(osu_benchmark):
     def run_after_init(self):
         """hooks to run after init phase"""
         # Note: device_buffers variable is inherited from the hpctestlib class and adds options to the launcher
-        # commands based on what device is set.
+        # commands (before setup) if not equal to 'cpu'. We set it to 'cpu' initially and change it later in this hook depending on the test.
         self.device_buffers = 'cpu'
         hooks.filter_valid_systems_by_device_type(self, required_device_type=self.device_type)
         is_cuda_module = utils.is_cuda_required_module(self.module_name)


### PR DESCRIPTION
1. The default `device_buffers` is set in `run_after_init`.
2. Changed the valid systems settings in `hooks.py` addressing https://github.com/EESSI/test-suite/issues/101 .