### PR TITLE
Add new hook to filter invalid scales based on features set in the config file

### DIFF
--- a/config/aws_mc.py
+++ b/config/aws_mc.py
@@ -13,7 +13,7 @@
 import os
 
 from eessi.testsuite.common_config import common_logging_config, common_eessi_init
-from eessi.testsuite.constants import FEATURES
+from eessi.testsuite.constants import FEATURES, SCALES
 
 # This config will write all staging, output and logging to subdirs under this prefix
 # Override with RFM_PREFIX environment variable
@@ -97,7 +97,7 @@ partition_defaults = {
     'environs': ['default'],
     'features': [
         FEATURES['CPU']
-    ],
+    ] + list(SCALES.keys()),
     'prepare_cmds': [
         'source %s' % common_eessi_init(),
         # Required when using srun as launcher with --export=NONE in partition access, in order to ensure job

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -17,7 +17,7 @@ site_configuration = {
                     'scheduler': 'local',
                     'launcher': 'local',
                     'environs': ['default'],
-                    'features': [FEATURES[CPU]],
+                    'features': [FEATURES[CPU]] + list(SCALES.keys()),
                     'processor': {'num_cpus': 2},
                     'resources': [
                         {

--- a/config/it4i_karolina.py
+++ b/config/it4i_karolina.py
@@ -52,7 +52,7 @@ site_configuration = {
                     'max_jobs': 120,
                     'features': [
                         FEATURES[CPU],
-                    ],
+                    ] + list(SCALES.keys()),
                     'descr': 'CPU Universal Compute Nodes, see https://docs.it4i.cz/karolina/hardware-overview/'
                 },
 # We don't have GPU budget on Karolina at this time
@@ -88,7 +88,7 @@ site_configuration = {
 #                     ],
 #                     'features': [
 #                         FEATURES[GPU],
-#                     ],
+#                     ] + list(SCALES.keys()),
 #                     'descr': 'GPU partition with accelerated nodes, see https://docs.it4i.cz/karolina/hardware-overview/'
 #                 },
             ]

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -58,7 +58,7 @@ site_configuration = {
                     ],
                     'features': [
                         FEATURES[CPU],
-                    ],
+                    ] + list(SCALES.keys()),
                     'descr': 'CPU partition Standard, see https://en-doc.vega.izum.si/architecture/'
                 },
                 {
@@ -97,7 +97,7 @@ site_configuration = {
                     ],
                     'features': [
                         FEATURES[GPU],
-                    ],
+                    ] + list(SCALES.keys()),
                     'descr': 'GPU partition, see https://en-doc.vega.izum.si/architecture/'
                 },
             ]

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -56,7 +56,9 @@ site_configuration = {
                             'options': ['--mem={size}'],
                         }
                     ],
-                    'features': [FEATURES[CPU]],
+                    # list(SCALES.keys()) adds all the scales from eessi.testsuite.constants as valid for thi partition
+                    # Can be modified if not all scales can run on this partition, see e.g. the surf_snellius.py config
+                    'features': [FEATURES[CPU]] + list(SCALES.keys()),
                 },
                 {
                     'name': 'gpu_partition',
@@ -94,7 +96,7 @@ site_configuration = {
                     'features': [
                         FEATURES[CPU],
                         FEATURES[GPU],
-                    ],
+                    ] + list(SCALES.keys()),
                     'extras': {
                         GPU_VENDOR: GPU_VENDORS[NVIDIA],
                     },

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -22,6 +22,9 @@ from eessi.testsuite.constants import *  # noqa: F403
 # Override with RFM_PREFIX environment variable
 reframe_prefix = os.path.join(os.environ['HOME'], 'reframe_runs')
 
+# Jobs that partially fill multiple nodes are not allowed on the GPU partition
+valid_scales_snellius_gpu = [s for s in SCALES if s not in ['1_cpn_2_nodes', '1_cpn_4_nodes']]
+
 # This is an example configuration file
 site_configuration = {
     'systems': [
@@ -49,7 +52,7 @@ site_configuration = {
                     ],
                     'features': [
                         FEATURES[CPU],
-                    ],
+                    ] + list(SCALES.keys()),
                     'descr': 'AMD Rome CPU partition with native EESSI stack'
                 },
                 {
@@ -68,7 +71,7 @@ site_configuration = {
                     ],
                     'features': [
                         FEATURES[CPU],
-                    ],
+                    ] + list(SCALES.keys()),
                     'descr': 'AMD Genoa CPU partition with native EESSI stack'
                 },
 
@@ -98,7 +101,7 @@ site_configuration = {
                     ],
                     'features': [
                         FEATURES[GPU],
-                    ],
+                    ] + valid_scales_snellius_gpu,
                     'extras': {
                         GPU_VENDOR: GPU_VENDORS[NVIDIA],
                     },

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -53,7 +53,7 @@ site_configuration = {
                     ],
                     'features': [
                         FEATURES[CPU],
-                    ],
+                    ] + list(SCALES.keys()),
                 },
                 {
                     'name': 'cpu_rome_512gb',
@@ -80,7 +80,7 @@ site_configuration = {
                     ],
                     'features': [
                         FEATURES[CPU],
-                    ],
+                    ] + list(SCALES.keys()),
                 },
                 {
                     'name': 'cpu_milan',
@@ -107,7 +107,7 @@ site_configuration = {
                     ],
                     'features': [
                         FEATURES[CPU],
-                    ],
+                    ] + list(SCALES.keys()),
                 },
                 {
                     'name': 'gpu_rome_a100_40gb',
@@ -128,7 +128,7 @@ site_configuration = {
                     },
                     'features': [
                         FEATURES[GPU],
-                    ],
+                    ] + list(SCALES.keys()),
                     'extras': {
                         GPU_VENDOR: GPU_VENDORS[NVIDIA],
                     },
@@ -169,7 +169,7 @@ site_configuration = {
                     },
                     'features': [
                         FEATURES[GPU],
-                    ],
+                    ] + list(SCALES.keys()),
                     'extras': {
                         GPU_VENDOR: GPU_VENDORS[NVIDIA],
                     },

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -62,4 +62,4 @@ SCALES = {
 }
 
 # When tests are filtered by the hooks, the valid_systems is set to this system name:
-INVALID_SYSTEM="INVALID_SYSTEM"
+INVALID_SYSTEM = "INVALID_SYSTEM"

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -60,3 +60,6 @@ SCALES = {
     '8_nodes': {'num_nodes': 8, 'node_part': 1},
     '16_nodes': {'num_nodes': 16, 'node_part': 1},
 }
+
+# When tests are filtered by the hooks, the valid_systems is set to this system name:
+INVALID_SYSTEM="INVALID_SYSTEM"

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -304,7 +304,7 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
     # test.valid_systems was set before, so append
     elif len(test.valid_systems) == 1:
         test.valid_systems[0] = f'{test.valid_systems[0]} {valid_systems}'
-    else
+    else:
         error_msg=f"test.valid_systems ({test.valid_systems}) is expected to contain one element."
         error_msg+=f" Instead, it contained {len(test.valid_systems)}."
         raise ValueError(error_msg)

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -304,6 +304,10 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
     # test.valid_systems was set before, so append
     elif len(test.valid_systems) == 1:
         test.valid_systems[0] = f'{test.valid_systems[0]} {valid_systems}'
+    else
+        error_msg=f"test.valid_systems ({test.valid_systems}) is expected to contain one element."
+        error_msg+=f" Instead, it contained {len(test.valid_systems)}."
+        raise ValueError(error_msg)
 
 
 def filter_supported_scales(test: rfm.RegressionTest):

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -286,9 +286,10 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
     """
     Sets test.valid_systems based on the valid_systems argument.
     - If valid_systems is an empty string, test.valid_systems is set equal to eessi.testsuite.constants.INVALID_SYSTEM
-    - If no test.valid_system was set yet, or it was at the default value ['*'], it is overwritten by [valid_system]
-    - If a test.valid_system was already set, valid_system is appended to it, which allows adding requests for multiple
-    partition features by different hooks.
+    - If test.valid_systems was an empty list, leave it as is (test should not be run)
+    - If test.valid_system was at the default value ['*'], it is overwritten by [valid_system]
+    - If a test.valid_system was already set and is a list of one element, valid_system is appended to it,
+    which allows adding requests for multiple partition features by different hooks.
     """
 
     # This indicates an invalid test that always has to be filtered

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -316,7 +316,7 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
         warn_msg = f"valid_systems has multiple ({len(test.valid_systems)}) items,"
         warn_msg += f" which is not supported by this hook."
         warn_msg += f" Make sure to handle filtering yourself."
-        warning.warn(warn_msg)
+        warnings.warn(warn_msg)
         return
 
 

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -283,9 +283,9 @@ def _assign_one_task_per_gpu(test: rfm.RegressionTest):
     log(f'num_tasks set to {test.num_tasks}')
 
 
-def filter_valid_test_scales(test: rfm.RegressionTest):
+def filter_supported_scales(test: rfm.RegressionTest):
     """
-    Request the test scale as feature. That we the test will not be generate for partitions that don't support this test scale.
+    Filter tests scales based on which scales are supported by each partition in the ReFrame configuration. Filtering is done using features. I.e. the current test scale is requested as a feature. Any partition that does not include this feature in the ReFrame configuration file will effectively be filtered out.
     """
     valid_systems = f'+{test.scale}'
     # test.valid_systems wasn't set yet, so set it

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -291,7 +291,7 @@ def filter_supported_scales(test: rfm.RegressionTest):
     # test.valid_systems wasn't set yet, so set it
     if len(test.valid_systems) == 0:
         test.valid_systems = [valid_systems]
-    # test.valid_systems likely contains requested features and extras set in another hook, so append
+    # test.valid_systems was already set. Append the current valid_systems
     elif len(test.valid_systems) == 1:
         test.valid_systems[0] = f'{test.valid_systems[0]} {valid_systems}'
 
@@ -301,6 +301,10 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
     """
     Filter valid_systems by required device type and by whether the module supports CUDA,
     unless valid_systems is specified with --setvar valid_systems=<comma-separated-list>.
+
+    Any invalid combination (e.g. a non-CUDA module with a required_device_type GPU) will
+    cause the valid_systems to be set to an empty string, and consequently the
+    test.valid_systems to an invalid system name (eessi.testsuite.constants.INVALID_SYSTEM).
     """
     is_cuda_module = is_cuda_required_module(test.module_name)
 
@@ -322,12 +326,14 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
         # test.valid_systems wasn't set yet, so set it
         if len(test.valid_systems) == 0:
             test.valid_systems = [valid_systems]
+        # test.valid_systems was already set. Append the current valid_systems
         elif len(test.valid_systems) == 1:
             test.valid_systems[0] = f'{test.valid_systems[0]} {valid_systems}'
-    # Explicitely set to empty because of invalid combination of module type and device type
-    # (even if other filters such as filter_valid_test_scales have already set it)
+    # Explicitely set to an invalid system name. The combination of module type and device type is invalid,
+    # so this test should never be generated.
+    # Note that this does (and should) overwrite any test.valid_systems that was potentially set before
     else:
-        test.valid_systems = []
+        test.valid_systems = [eessi.testsuite.constants.INVALID_SYSTEM]
 
     log(f'valid_systems set to {test.valid_systems}')
 

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -333,7 +333,7 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
     # so this test should never be generated.
     # Note that this does (and should) overwrite any test.valid_systems that was potentially set before
     else:
-        test.valid_systems = [eessi.testsuite.constants.INVALID_SYSTEM]
+        test.valid_systems = [INVALID_SYSTEM]
 
     log(f'valid_systems set to {test.valid_systems}')
 

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -298,9 +298,10 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
 
     # test.valid_systems wasn't set yet, so set it
     if len(test.valid_systems) == 0:
-        test.valid_systems = [valid_systems]
+        # test.valid_systems is empty, meaning all tests are filtered out. This hook shouldn't change that
+        pass
     # test.valid_systems still at default value, so overwrite
-    elif len(test.valid_systems) == 1 and test.valid_systems[0] == '*':  
+    elif len(test.valid_systems) == 1 and test.valid_systems[0] == '*':
         test.valid_systems = [valid_systems]
     # test.valid_systems was set before, so append
     elif len(test.valid_systems) == 1:

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -285,9 +285,10 @@ def _assign_one_task_per_gpu(test: rfm.RegressionTest):
 def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
     """
     Sets test.valid_systems based on the valid_systems argument.
-    - When valid_systems is an empty string, test.valid_systems will be set equal to eessi.testsuite.constants.INVALID_SYSTEM
-    - When no test.valid_system was set yet, or it was at the default value ['*'], it will be overwritten by [valid_system]
-    - When a test.valid_system was already set, valid_system will be appended to it. This allows adding requests for multiple partition features by different hooks.
+    - If valid_systems is an empty string, test.valid_systems is set equal to eessi.testsuite.constants.INVALID_SYSTEM
+    - If no test.valid_system was set yet, or it was at the default value ['*'], it is overwritten by [valid_system]
+    - If a test.valid_system was already set, valid_system is appended to it, which allows adding requests for multiple
+    partition features by different hooks.
     """
 
     # This indicates an invalid test that always has to be filtered
@@ -305,14 +306,16 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
     elif len(test.valid_systems) == 1:
         test.valid_systems[0] = f'{test.valid_systems[0]} {valid_systems}'
     else:
-        error_msg=f"test.valid_systems ({test.valid_systems}) is expected to contain one element."
-        error_msg+=f" Instead, it contained {len(test.valid_systems)}."
+        error_msg = f"test.valid_systems ({test.valid_systems}) is expected to contain one element."
+        error_msg += f" Instead, it contained {len(test.valid_systems)}."
         raise ValueError(error_msg)
 
 
 def filter_supported_scales(test: rfm.RegressionTest):
     """
-    Filter tests scales based on which scales are supported by each partition in the ReFrame configuration. Filtering is done using features. I.e. the current test scale is requested as a feature. Any partition that does not include this feature in the ReFrame configuration file will effectively be filtered out.
+    Filter tests scales based on which scales are supported by each partition in the ReFrame configuration.
+    Filtering is done using features, i.e. the current test scale is requested as a feature.
+    Any partition that does not include this feature in the ReFrame configuration file will effectively be filtered out.
     """
     valid_systems = f'+{test.scale}'
 

--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -50,6 +50,9 @@ class GROMACS_EESSI(gromacs_check):
     def run_after_init(self):
         """Hooks to run after the init phase"""
 
+        # Filter invalid sizes
+        hooks.filter_valid_test_scales(self)
+
         # Make sure that GPU tests run in partitions that support running on a GPU,
         # and that CPU-only tests run in partitions that support running CPU-only.
         # Also support setting valid_systems on the cmd line.

--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -50,8 +50,8 @@ class GROMACS_EESSI(gromacs_check):
     def run_after_init(self):
         """Hooks to run after the init phase"""
 
-        # Filter invalid sizes
-        hooks.filter_valid_test_scales(self)
+        # Filter on which scales are supported by the partitions defined in the ReFrame configuration
+        hooks.filter_supported_scales(self)
 
         # Make sure that GPU tests run in partitions that support running on a GPU,
         # and that CPU-only tests run in partitions that support running CPU-only.

--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -42,7 +42,7 @@ from eessi.testsuite.utils import find_modules, log
 class GROMACS_EESSI(gromacs_check):
     scale = parameter(SCALES.keys())
     valid_prog_environs = ['default']
-    valid_systems = []
+    valid_systems = ['*']
     time_limit = '30m'
     module_name = parameter(find_modules('GROMACS'))
 

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -42,7 +42,7 @@ class osu_pt_2_pt(osu_benchmark):
     ''' Run-only OSU test '''
     scale = parameter(filter_scales_pt2pt())
     valid_prog_environs = ['default']
-    valid_systems = []
+    valid_systems = ['*']
     time_limit = '30m'
     module_name = parameter(find_modules('OSU-Micro-Benchmarks'))
     # Device type for non-cuda OSU-Micro-Benchmarks should run on hosts of both node types. To do this the default

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -57,6 +57,9 @@ class osu_pt_2_pt(osu_benchmark):
     @run_after('init')
     def run_after_init(self):
         """hooks to run after init phase"""
+        # Filter on which scales are supported by the partitions defined in the ReFrame configuration
+        hooks.filter_supported_scales(self)
+
         hooks.filter_valid_systems_by_device_type(self, required_device_type=self.device_type)
         is_cuda_module = utils.is_cuda_required_module(self.module_name)
         # This part of the hook is meant to be for the OSU cpu tests. This is required since the non CUDA module should

--- a/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
+++ b/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
@@ -70,6 +70,9 @@ class TENSORFLOW_EESSI(rfm.RunOnlyRegressionTest):
     @run_after('init')
     def run_after_init(self):
         """hooks to run after the init phase"""
+        # Filter on which scales are supported by the partitions defined in the ReFrame configuration
+        hooks.filter_supported_scales(self)
+
         hooks.filter_valid_systems_by_device_type(self, required_device_type=self.device_type)
         hooks.set_modules(self)
         hooks.set_tag_scale(self)

--- a/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
+++ b/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
@@ -16,7 +16,7 @@ class TENSORFLOW_EESSI(rfm.RunOnlyRegressionTest):
     # This test can run at any scale, so parameterize over all known SCALES
     scale = parameter(SCALES.keys())
     valid_prog_environs = ['default']
-    valid_systems = []
+    valid_systems = ['*']
 
     # Parameterize over all modules that start with TensorFlow
     module_name = parameter(utils.find_modules('TensorFlow'))


### PR DESCRIPTION
This avoids issues on Snellius GPU, where partially allocating multiple nodes is not allowed by the Slurm configuration.