### PR TITLE
support always requesting GPUs on partitions that require it

### DIFF
--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -11,6 +11,7 @@ GPU_VENDOR = 'GPU_VENDOR'
 INTEL = 'INTEL'
 NODE = 'NODE'
 NVIDIA = 'NVIDIA'
+ALWAYS_REQUEST_GPUS = 'ALWAYS_REQUEST_GPUS'
 
 DEVICE_TYPES = {
     CPU: 'cpu',
@@ -31,6 +32,7 @@ TAGS = {
 FEATURES = {
     CPU: 'cpu',
     GPU: 'gpu',
+    ALWAYS_REQUEST_GPUS: 'always_request_gpus',
 }
 
 GPU_VENDORS = {

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -468,4 +468,4 @@ def check_always_request_gpus(test: rfm.RegressionTest):
     """
     if FEATURES[ALWAYS_REQUEST_GPUS] in test.current_partition.features and not test.num_gpus_per_node:
         test.num_gpus_per_node = test.default_num_gpus_per_node
-        log(f'Set num_gpus_per_node for partition {test.current_partition.name} to {test.num_gpus_per_node}')
+        log(f'num_gpus_per_node set to {test.num_gpus_per_node} for partition {test.current_partition.name}')

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -308,7 +308,7 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
 
     # test.valid_systems wasn't set yet, so set it
     if len(test.valid_systems) == 0 or test.valid_systems == [INVALID_SYSTEM]:
-        # test.valid_systems is empty, meaning all tests are filtered out. This hook shouldn't change that
+        # test.valid_systems is empty or invalid, meaning all tests are filtered out. This hook shouldn't change that
         return
     # test.valid_systems still at default value, so overwrite
     elif len(test.valid_systems) == 1 and test.valid_systems[0] == '*':

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -12,7 +12,7 @@ from eessi.testsuite.utils import (get_max_avail_gpus_per_node, is_cuda_required
                                    check_proc_attribute_defined)
 
 
-def assign_default_num_cpus_per_node(test: rfm.RegressionTest):
+def _assign_default_num_cpus_per_node(test: rfm.RegressionTest):
     """
     Check if the default number of cpus per node is already defined in the test
     (e.g. by earlier hooks like set_tag_scale).
@@ -34,7 +34,7 @@ def assign_default_num_cpus_per_node(test: rfm.RegressionTest):
     log(f'default_num_cpus_per_node set to {test.default_num_cpus_per_node}')
 
 
-def assign_default_num_gpus_per_node(test: rfm.RegressionTest):
+def _assign_default_num_gpus_per_node(test: rfm.RegressionTest):
     """
     Check if the default number of gpus per node is already defined in the test
     (e.g. by earlier hooks like set_tag_scale).
@@ -98,10 +98,10 @@ def assign_tasks_per_compute_unit(test: rfm.RegressionTest, compute_unit: str, n
             f' default num_gpus_per_node ({test.default_num_gpus_per_node}) must be defined and have integer values.'
         )
 
-    assign_default_num_cpus_per_node(test)
+    _assign_default_num_cpus_per_node(test)
 
     if FEATURES[GPU] in test.current_partition.features:
-        assign_default_num_gpus_per_node(test)
+        _assign_default_num_gpus_per_node(test)
 
     if compute_unit == COMPUTE_UNIT[GPU]:
         _assign_one_task_per_gpu(test)

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -114,7 +114,7 @@ def assign_tasks_per_compute_unit(test: rfm.RegressionTest, compute_unit: str, n
     else:
         raise ValueError(f'compute unit {compute_unit} is currently not supported')
 
-    check_always_request_gpus(test)
+    _check_always_request_gpus(test)
 
 
 def _assign_num_tasks_per_node(test: rfm.RegressionTest, num_per: int = 1):
@@ -466,7 +466,7 @@ def set_compact_thread_binding(test: rfm.RegressionTest):
     log(f'Set environment variable KMP_AFFINITY to {test.env_vars["KMP_AFFINITY"]}')
 
 
-def check_always_request_gpus(test: rfm.RegressionTest):
+def _check_always_request_gpus(test: rfm.RegressionTest):
     """
     Make sure we always request enough GPUs if required for the current GPU partition (cluster-specific policy)
     """

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -307,7 +307,7 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
         return
 
     # test.valid_systems wasn't set yet, so set it
-    if len(test.valid_systems) == 0:
+    if len(test.valid_systems) == 0 or test.valid_systems == [INVALID_SYSTEM]:
         # test.valid_systems is empty, meaning all tests are filtered out. This hook shouldn't change that
         return
     # test.valid_systems still at default value, so overwrite
@@ -318,8 +318,8 @@ def _set_or_append_valid_systems(test: rfm.RegressionTest, valid_systems: str):
         test.valid_systems[0] = f'{test.valid_systems[0]} {valid_systems}'
     else:
         warn_msg = f"valid_systems has multiple ({len(test.valid_systems)}) items,"
-        warn_msg += f" which is not supported by this hook."
-        warn_msg += f" Make sure to handle filtering yourself."
+        warn_msg += " which is not supported by this hook."
+        warn_msg += " Make sure to handle filtering yourself."
         warnings.warn(warn_msg)
         return
 
@@ -336,6 +336,7 @@ def filter_supported_scales(test: rfm.RegressionTest):
     _set_or_append_valid_systems(test, valid_systems)
 
     log(f'valid_systems set to {test.valid_systems}')
+
 
 def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_device_type: str):
     """

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -142,8 +142,8 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
             # Skip the single node test if there is only 1 device in the node.
             self.skip_if(
                 SCALES[self.scale]['num_nodes'] == 1 and self.default_num_gpus_per_node == 1,
-                f"There is only 1 GPU device in this scale ({self.scale}). "
-                f"Skipping tests with device_type={DEVICE_TYPES[GPU]} involving only 1 GPU."
+                f"There is only 1 GPU device in this scale ({self.scale})."
+                f" Skipping tests with device_type={DEVICE_TYPES[GPU]} involving only 1 GPU."
             )
 
 

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -97,13 +97,6 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
             self.device_buffers = 'cpu'
 
     @run_after('init')
-    def adjust_executable_opts(self):
-        """The option "D D" is only meant for Devices if and not for CPU tests. This option is added by hpctestlib to
-        all pt2pt tests which is not required."""
-        if self.device_type == DEVICE_TYPES[CPU]:
-            self.executable_opts = [ele for ele in self.executable_opts if ele != 'D']
-
-    @run_after('init')
     def set_tag_ci(self):
         """ Setting tests under CI tag. """
         if (self.benchmark_info[0] in ['mpi.pt2pt.osu_latency', 'mpi.pt2pt.osu_bw']):
@@ -124,6 +117,16 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
         option for osu_bw or osu_latency). We run till message size 8 (-m 8) which significantly reduces memory
         requirement."""
         self.extra_resources = {'memory': {'size': '12GB'}}
+
+    @run_after('setup')
+    def adjust_executable_opts(self):
+        """The option "D D" is only meant for Devices if and not for CPU tests.
+        This option is added by hpctestlib in a @run_before('setup') to all pt2pt tests which is not required.
+        Therefore we must override it *after* the 'setup' phase
+        """
+        if self.device_type == DEVICE_TYPES[CPU]:
+            self.executable_opts = [ele for ele in self.executable_opts if ele != 'D']
+
 
     @run_after('setup')
     def set_num_tasks_per_node(self):

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -137,13 +137,15 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
         allocation for to perform any activity in the GPU nodes.
         """
         if self.device_type == DEVICE_TYPES[GPU]:
-            self.num_gpus_per_node = self.default_num_gpus_per_node
-            # Skip the single node test if there is only 1 device in the node.
+            # Skip scales with only 1 GPU device and single-node tests with only 1 GPU device in the node
             self.skip_if(
                 SCALES[self.scale]['num_nodes'] == 1 and self.default_num_gpus_per_node == 1,
-                f"There is only 1 GPU device in this scale ({self.scale})."
+                f"There is only 1 GPU device for scale={self.scale} or present in the node."
                 f" Skipping tests with device_type={DEVICE_TYPES[GPU]} involving only 1 GPU."
             )
+            if not self.num_gpus_per_node:
+                self.num_gpus_per_node = self.default_num_gpus_per_node
+                log(f'num_gpus_per_node set to {self.num_gpus_per_node} for partition {self.current_partition.name}')
 
 
 @rfm.simple_test

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -136,7 +136,6 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
         This test does not require gpus and is for host to host within GPU nodes. But some systems do require a GPU
         allocation for to perform any activity in the GPU nodes.
         """
-        # if FEATURES[GPU] in self.current_partition.features and utils.is_cuda_required_module(self.module_name):
         if self.device_type == DEVICE_TYPES[GPU]:
             self.num_gpus_per_node = self.default_num_gpus_per_node
             # Skip the single node test if there is only 1 device in the node.

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -140,8 +140,7 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
     @run_after('setup')
     def set_num_gpus_per_node(self):
         """
-        This test does not require gpus and is for host to host within GPU nodes. But some systems do require a GPU
-        allocation for to perform any activity in the GPU nodes.
+        Set number of GPUs per node for GPU-to-GPU tests
         """
         if self.device_type == DEVICE_TYPES[GPU]:
             # Skip single-node tests with less than 2 GPU devices in the node

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -119,27 +119,12 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
             self.env_vars = {'LD_LIBRARY_PATH': '$EBROOTCUDA/stubs/lib64:$LD_LIBRARY_PATH'}
 
     @run_after('setup')
-    def set_num_tasks_per_node(self):
-        """ Setting number of tasks per node and cpus per task in this function. This function sets num_cpus_per_task
-        for 1 node and 2 node options where the request is for full nodes."""
-        if(SCALES.get(self.scale).get('num_nodes') == 1):
-            hooks.assign_tasks_per_compute_unit(self, COMPUTE_UNIT[NODE], 2)
-        else:
-            hooks.assign_tasks_per_compute_unit(self, COMPUTE_UNIT[NODE])
-
-    @run_after('setup')
     def set_num_gpus_per_node(self):
         """
         This test does not require gpus and is for host to host within GPU nodes. But some systems do require a GPU
         allocation for to perform any activity in the GPU nodes.
         """
-        if(FEATURES[GPU] in self.current_partition.features and not utils.is_cuda_required_module(self.module_name)):
-            max_avail_gpus_per_node = utils.get_max_avail_gpus_per_node(self)
-            # Here for the 2_node test we assign max_avail_gpus_per_node but some systems cannot allocate 1_cpn_2_nodes
-            # for GPUs but need all gpus allocated within the 2 nodes for this work which. The test may fail under such
-            # conditions for the scale 1_cpn_2_nodes because it is simply not allowed.
-            self.num_gpus_per_node = self.default_num_gpus_per_node or max_avail_gpus_per_node
-        elif(FEATURES[GPU] in self.current_partition.features and utils.is_cuda_required_module(self.module_name)):
+        if(FEATURES[GPU] in self.current_partition.features and utils.is_cuda_required_module(self.module_name)):
             max_avail_gpus_per_node = utils.get_max_avail_gpus_per_node(self)
             if(SCALES.get(self.scale).get('num_nodes') == 1):
                 # Skip the single node test if there is only 1 device in the node.
@@ -151,6 +136,15 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
                 # Note these settings are for 1_cpn_2_nodes. In that case we want to test for only 1 GPU per node since
                 # we have not requested for full nodes.
                 self.num_gpus_per_node = self.default_num_gpus_per_node or max_avail_gpus_per_node
+
+    @run_after('setup')
+    def set_num_tasks_per_node(self):
+        """ Setting number of tasks per node and cpus per task in this function. This function sets num_cpus_per_task
+        for 1 node and 2 node options where the request is for full nodes."""
+        if(SCALES.get(self.scale).get('num_nodes') == 1):
+            hooks.assign_tasks_per_compute_unit(self, COMPUTE_UNIT[NODE], 2)
+        else:
+            hooks.assign_tasks_per_compute_unit(self, COMPUTE_UNIT[NODE])
 
 
 @rfm.simple_test

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,9 @@ namespace_packages = eessi
 
 [options.packages.find]
 include = eessi*
+
+[flake8]
+max-line-length = 120
+# ignore star imports (F403, F405)
+# ignore obsolete warning (W503)
+ignore = F403, F405, W503


### PR DESCRIPTION
fixes #115 

changes:
- add feature `always_request_gpus` for partitions that require it, and check for it in hook `check_always_request_gpus`, called at end of hook `assign_tasks_per_compute_unit` to ensure it is run *after* task assignment
- small hook updates to allow simplifying the OSU test (done for the pt2pt test, not yet for collective test)
- filter scale `2_cores` for device_type `gpu` (in addition to skipping single-node tests with only 1 GPU present in the node), as this scale has only 1 GPU (pt2pt test)
- add flake8 configuration to setup.cfg


i did not add the new feature to the config files in the repo as there are currently no partitions that have both feature `cpu` and `gpu`, although it does not hurt to add it to all GPU partitions that do not have feature `cpu` (it should have no effect).
