### PR TITLE
Add common config item to redirect the report file to the same directory as e.g. the perflog

### DIFF
--- a/config/aws_mc.py
+++ b/config/aws_mc.py
@@ -12,7 +12,7 @@
 
 import os
 
-from eessi.testsuite.common_config import common_logging_config, common_eessi_init
+from eessi.testsuite.common_config import common_logging_config, common_general_config, common_eessi_init
 from eessi.testsuite.constants import FEATURES, SCALES
 
 # This config will write all staging, output and logging to subdirs under this prefix
@@ -86,7 +86,7 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }
+        }.update(common_general_config(reframe_prefix))
     ],
 }
 

--- a/config/aws_mc.py
+++ b/config/aws_mc.py
@@ -86,7 +86,8 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }.update(common_general_config(reframe_prefix))
+            **common_general_config(reframe_prefix)
+        }
     ],
 }
 

--- a/config/it4i_karolina.py
+++ b/config/it4i_karolina.py
@@ -15,7 +15,7 @@
 
 import os
 
-from eessi.testsuite.common_config import common_logging_config, common_eessi_init
+from eessi.testsuite.common_config import common_logging_config, common_general_config, common_eessi_init
 from eessi.testsuite.constants import *  # noqa: F403
 
 # This config will write all staging, output and logging to subdirs under this prefix
@@ -108,6 +108,6 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }
+        }.update(common_general_config(reframe_prefix))
     ],
 }

--- a/config/it4i_karolina.py
+++ b/config/it4i_karolina.py
@@ -108,6 +108,7 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }.update(common_general_config(reframe_prefix))
+            **common_general_config(reframe_prefix)
+        }
     ],
 }

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -15,7 +15,7 @@
 
 import os
 
-from eessi.testsuite.common_config import common_logging_config, common_eessi_init
+from eessi.testsuite.common_config import common_logging_config, common_general_config, common_eessi_init
 from eessi.testsuite.constants import *  # noqa: F403
 
 # This config will write all staging, output and logging to subdirs under this prefix
@@ -117,6 +117,6 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }
+        }.update(common_general_config(reframe_prefix))
     ],
 }

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -117,6 +117,7 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }.update(common_general_config(reframe_prefix))
+            **common_general_config(reframe_prefix)
+        }
     ],
 }

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -118,7 +118,7 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-            **common_general_config(reframe_prefix)
+            **common_general_config()
         }
     ],
 }

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -19,7 +19,7 @@ Example configuration file
 """
 import os
 
-from eessi.testsuite.common_config import common_logging_config, format_perfvars, perflog_format
+from eessi.testsuite.common_config import common_logging_config, common_general_config, format_perfvars, perflog_format
 from eessi.testsuite.constants import *  # noqa: F403
 
 
@@ -118,7 +118,7 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }
+        }.update(common_general_config(reframe_prefix))
     ],
 }
 

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -118,7 +118,8 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }.update(common_general_config(reframe_prefix))
+            **common_general_config(reframe_prefix)
+        }
     ],
 }
 

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -129,4 +129,3 @@ site_configuration = {
         }
     ],
 }
-

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -125,6 +125,8 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }.update(common_general_config(reframe_prefix))
+            **common_general_config(reframe_prefix)
+        }
     ],
 }
+

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -15,7 +15,7 @@
 
 import os
 
-from eessi.testsuite.common_config import common_logging_config, common_eessi_init
+from eessi.testsuite.common_config import common_logging_config, common_general_config, common_eessi_init
 from eessi.testsuite.constants import *  # noqa: F403
 
 # This config will write all staging, output and logging to subdirs under this prefix
@@ -125,6 +125,6 @@ site_configuration = {
             # Enable automatic detection of CPU architecture for each partition
             # See https://reframe-hpc.readthedocs.io/en/stable/configure.html#auto-detecting-processor-information
             'remote_detect': True,
-        }
+        }.update(common_general_config(reframe_prefix))
     ],
 }

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -6,7 +6,7 @@
 from reframe.core.backends import register_launcher
 from reframe.core.launchers import JobLauncher
 
-from eessi.testsuite.common_config import common_logging_config, common_eessi_init
+from eessi.testsuite.common_config import common_logging_config, common_general_config, common_eessi_init
 from eessi.testsuite.constants import *  # noqa: F403
 
 account = "my-slurm-account"
@@ -226,7 +226,7 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
-        }
+        }.update(common_general_config(reframe_prefix))
     ],
     'logging': common_logging_config(),
 }

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -226,7 +226,8 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
-        }.update(common_general_config(reframe_prefix))
+            **common_general_config(reframe_prefix)
+        }
     ],
     'logging': common_logging_config(),
 }

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -226,7 +226,7 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
-            **common_general_config(reframe_prefix)
+            **common_general_config()
         }
     ],
     'logging': common_logging_config(),

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -69,6 +69,19 @@ def common_logging_config(prefix=None):
         ],
     }]
 
+def common_general_config(prefix=None):
+    """
+    return common configuration for the 'general' section of the ReFrame configuration file
+    :param: prefix: prefix for the report_file
+    """
+    prefix = os.getenv('RFM_PREFIX', prefix if prefix else '.')
+    reportdir = os.path.join(prefix, 'report_files')
+    os.makedirs(reportdir)
+
+    return [{
+        'report_file': os.path.join(reportdir, 'run-report-{sessionid}.json'
+    }]
+
 def common_eessi_init(eessi_version=None):
     """
     Returns the full path that should be sourced to initialize the EESSI environment for a given version of EESSI.

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -69,6 +69,7 @@ def common_logging_config(prefix=None):
         ],
     }]
 
+
 def common_general_config(prefix=None):
     """
     return common configuration for the 'general' section of the ReFrame configuration file
@@ -81,6 +82,7 @@ def common_general_config(prefix=None):
     return [{
         'report_file': os.path.join(reportdir, 'run-report-{sessionid}.json')
     }]
+
 
 def common_eessi_init(eessi_version=None):
     """

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -77,7 +77,7 @@ def common_general_config(prefix=None):
     """
     prefix = os.getenv('RFM_PREFIX', prefix if prefix else '.')
     reportdir = os.path.join(prefix, 'report_files')
-    os.makedirs(reportdir)
+    os.makedirs(reportdir, exist_ok=True)
 
     return {
         'report_file': os.path.join(reportdir, 'run-report-{sessionid}.json')

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -79,9 +79,9 @@ def common_general_config(prefix=None):
     reportdir = os.path.join(prefix, 'report_files')
     os.makedirs(reportdir)
 
-    return [{
+    return {
         'report_file': os.path.join(reportdir, 'run-report-{sessionid}.json')
-    }]
+    }
 
 
 def common_eessi_init(eessi_version=None):

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -79,7 +79,7 @@ def common_general_config(prefix=None):
     os.makedirs(reportdir)
 
     return [{
-        'report_file': os.path.join(reportdir, 'run-report-{sessionid}.json'
+        'report_file': os.path.join(reportdir, 'run-report-{sessionid}.json')
     }]
 
 def common_eessi_init(eessi_version=None):


### PR DESCRIPTION
It would be nice if we can add a timestamp instead of the session id, so we can more easily relate these to their corresponding performance logs. But since it is a common config item, we can easily update that later.