### PR TITLE
software.eessi.io is now also present on the AWS MC cluster

### DIFF
--- a/CI/aws_mc/ci_config.sh
+++ b/CI/aws_mc/ci_config.sh
@@ -2,7 +2,3 @@
 if [ -z "${REFRAME_ARGS}" ]; then
    REFRAME_ARGS="--tag CI --tag 1_node|2_nodes"
 fi
-# For now, software.eessi.io is not yet deployed on login nodes of the AWS MC cluster
-if [ -z "${EESSI_CVMFS_REPO}" ]; then
-   EESSI_CVMFS_REPO="/cvmfs/pilot.eessi-hpc.org"
-fi


### PR DESCRIPTION
So remove the exception for the CI on `aws_mc` to use the pilot repo.