### PR TITLE
Prevent running scorecards CI on forks

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,6 +22,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    if: github.repository == 'EESSI/test-suite'   # Prevent running on forks
     name: Scorecards analysis
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Prevent running of scorecards CI workflow on forks