### PR TITLE
Use compact process binding for gromacs

### DIFF
--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -18,7 +18,10 @@ site_configuration = {
                     'launcher': 'local',
                     'environs': ['default'],
                     'features': [FEATURES[CPU]] + list(SCALES.keys()),
-                    'processor': {'num_cpus': 2},
+                    'processor': {
+                        'num_cpus': 2,
+                        'num_cpus_per_core': 1,
+                    },
                     'resources': [
                         {
                             'name': 'memory',

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -441,7 +441,7 @@ def set_compact_process_binding(test: rfm.RegressionTest):
         log(f'Set environment variable I_MPI_PIN_CELL to {test.env_vars["I_MPI_PIN_CELL"]}')
         log(f'Set environment variable I_MPI_PIN_DOMAIN to {test.env_vars["I_MPI_PIN_DOMAIN"]}')
         log('Set environment variable OMPI_MCA_rmaps_base_mapping_policy to '
-           f'{test.env_vars["OMPI_MCA_rmaps_base_mapping_policy"]}')
+            f'{test.env_vars["OMPI_MCA_rmaps_base_mapping_policy"]}')
     elif test.current_partition.launcher_type().registered_name == 'srun':
         # Set compact binding for SLURM. Only effective if the task/affinity plugin is enabled
         # and when number of tasks times cpus per task equals either socket, core or thread count

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -436,7 +436,7 @@ def set_compact_process_binding(test: rfm.RegressionTest):
     # Other launchers may or may not do the correct binding
     test.env_vars['I_MPI_PIN_CELL'] = 'core'  # Don't bind to hyperthreads, only to physcial cores
     test.env_vars['I_MPI_PIN_DOMAIN'] = '%s:compact' % physical_cpus_per_task
-    test.env_vars['OMPI_MCA_rmaps_base_mapping_policy'] = 'node:PE=%s' % physical_cpus_per_task
+    test.env_vars['OMPI_MCA_rmaps_base_mapping_policy'] = 'slot:PE=%s' % physical_cpus_per_task
     # Default binding for SLURM. Only effective if the task/affinity plugin is enabled
     # and when number of tasks times cpus per task equals either socket, core or thread count
     test.env_vars['SLURM_CPU_BIND'] = 'verbose'

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -437,9 +437,11 @@ def set_compact_process_binding(test: rfm.RegressionTest):
     test.env_vars['I_MPI_PIN_CELL'] = 'core'  # Don't bind to hyperthreads, only to physcial cores
     test.env_vars['I_MPI_PIN_DOMAIN'] = '%s:compact' % physical_cpus_per_task
     test.env_vars['OMPI_MCA_rmaps_base_mapping_policy'] = 'slot:PE=%s' % physical_cpus_per_task
-    # Default binding for SLURM. Only effective if the task/affinity plugin is enabled
-    # and when number of tasks times cpus per task equals either socket, core or thread count
-    test.env_vars['SLURM_CPU_BIND'] = 'verbose'
+    if test.current_partition.launcher_type().registered_name == 'srun':
+        # Set compact binding for SLURM. Only effective if the task/affinity plugin is enabled
+        # and when number of tasks times cpus per task equals either socket, core or thread count
+        test.env_vars['SLURM_DISTRIBUTION'] = 'block:block'
+        test.env_vars['SLURM_CPU_BIND'] = 'verbose'
     log(f'Set environment variable I_MPI_PIN_DOMAIN to {test.env_vars["I_MPI_PIN_DOMAIN"]}')
     log('Set environment variable OMPI_MCA_rmaps_base_mapping_policy to '
         f'{test.env_vars["OMPI_MCA_rmaps_base_mapping_policy"]}')

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -441,7 +441,7 @@ def set_compact_process_binding(test: rfm.RegressionTest):
         log(f'Set environment variable I_MPI_PIN_CELL to {test.env_vars["I_MPI_PIN_CELL"]}')
         log(f'Set environment variable I_MPI_PIN_DOMAIN to {test.env_vars["I_MPI_PIN_DOMAIN"]}')
         log('Set environment variable OMPI_MCA_rmaps_base_mapping_policy to '
-        f'{test.env_vars["OMPI_MCA_rmaps_base_mapping_policy"]}')
+           f'{test.env_vars["OMPI_MCA_rmaps_base_mapping_policy"]}')
     elif test.current_partition.launcher_type().registered_name == 'srun':
         # Set compact binding for SLURM. Only effective if the task/affinity plugin is enabled
         # and when number of tasks times cpus per task equals either socket, core or thread count

--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -113,3 +113,11 @@ class EESSI_GROMACS(gromacs_check):
 
         self.env_vars['OMP_NUM_THREADS'] = omp_num_threads
         log(f'env_vars set to {self.env_vars}')
+
+    @run_after('setup')
+    def set_binding_policy(self):
+        """
+        Default process binding may depend on the launcher used. We've seen some variable performance.
+        Better set it explicitely to make sure process migration cannot cause such variations.
+        """
+        hooks.set_compact_process_binding(self)

--- a/eessi/testsuite/utils.py
+++ b/eessi/testsuite/utils.py
@@ -148,4 +148,4 @@ def check_proc_attribute_defined(test: rfm.RegressionTest, attribute) -> bool:
             "The function utils.proc_attribute_defined should only be called after the setup() phase of ReFrame."
             "This is a programming error, please report this issue."
         )
-        raise AttributeError(msg)
+    raise AttributeError(msg)


### PR DESCRIPTION
Without process binding, `mpirun` was binding processes to NUMA domains. I'm not sure why, but occasionally I saw some cores  on Snellius being empty, while others seemed to run 2 processes. These runs would run about 10x slower than normal. This must be some weird behaviour from the OS thread scheduler. With process binding, performance is more consistent: while I still see some variation, I don't see the extremely slow runs anymore. Also, it seems performance also went up a bit (few %) on average, though it is a bit hard to be sure with the natural variation between runs.

Depends on:

- [x] https://github.com/EESSI/test-suite/pull/137