### PR TITLE
Rename scale tags 1_cpn_2_nodes and 1_cpn_4_nodes

### DIFF
--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -51,7 +51,9 @@ SCALES = {
     '1_core': {'num_nodes': 1, 'num_cpus_per_node': 1, 'num_gpus_per_node': 1},
     '2_cores': {'num_nodes': 1, 'num_cpus_per_node': 2, 'num_gpus_per_node': 1},
     '4_cores': {'num_nodes': 1, 'num_cpus_per_node': 4, 'num_gpus_per_node': 1},
+    # renamed after v0.2.0 from 1_cpn_2_nodes to make more unique
     '1cpn_2nodes': {'num_nodes': 2, 'num_cpus_per_node': 1, 'num_gpus_per_node': 1},
+    # renamed after v0.2.0 from 1_cpn_4_nodes to make more unique
     '1cpn_4nodes': {'num_nodes': 4, 'num_cpus_per_node': 1, 'num_gpus_per_node': 1},
     '1_8_node': {'num_nodes': 1, 'node_part': 8},  # 1/8 node
     '1_4_node': {'num_nodes': 1, 'node_part': 4},  # 1/4 node

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -51,8 +51,8 @@ SCALES = {
     '1_core': {'num_nodes': 1, 'num_cpus_per_node': 1, 'num_gpus_per_node': 1},
     '2_cores': {'num_nodes': 1, 'num_cpus_per_node': 2, 'num_gpus_per_node': 1},
     '4_cores': {'num_nodes': 1, 'num_cpus_per_node': 4, 'num_gpus_per_node': 1},
-    '1_cpn_2_nodes': {'num_nodes': 2, 'num_cpus_per_node': 1, 'num_gpus_per_node': 1},
-    '1_cpn_4_nodes': {'num_nodes': 4, 'num_cpus_per_node': 1, 'num_gpus_per_node': 1},
+    '1cpn_2nodes': {'num_nodes': 2, 'num_cpus_per_node': 1, 'num_gpus_per_node': 1},
+    '1cpn_4nodes': {'num_nodes': 4, 'num_cpus_per_node': 1, 'num_gpus_per_node': 1},
     '1_8_node': {'num_nodes': 1, 'node_part': 8},  # 1/8 node
     '1_4_node': {'num_nodes': 1, 'node_part': 4},  # 1/4 node
     '1_2_node': {'num_nodes': 1, 'node_part': 2},  # 1/2 node

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -114,7 +114,7 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
     @run_after('init')
     def set_mem(self):
         """ Setting an extra job option of memory. This test has only 4 possibilities: 1_node, 2_nodes, 2_cores and
-        1_cpn_2_nodes. This is implemented for all cases including full node cases. The requested memory may seem large
+        1cpn_2nodes. This is implemented for all cases including full node cases. The requested memory may seem large
         and the test requires at least 4.5 GB per core at the minimum for the full test when run with validation (-c
         option for osu_bw or osu_latency). We run till message size 8 (-m 8) which significantly reduces memory
         requirement."""


### PR DESCRIPTION
fixes https://github.com/EESSI/test-suite/issues/136

adding a warning for the removed scales is not advisable here, as then you still get non-unique tags

however, from the reframe output it's pretty clear there's something wrong with the user provided tags:
>Loaded 624 test(s)
Generated 36 test case(s)
Filtering test cases(s) by name: 36 remaining
Filtering test cases(s) by tags: 0 remaining
Filtering test cases(s) by other attributes: 0 remaining
Final number of test cases: 0
