### PR TITLE
Reduce the iteration count to make the OSU tests run faster, especially on slower interconnects

### DIFF
--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -53,6 +53,11 @@ class EESSI_OSU_Micro_Benchmarks_pt2pt(osu_benchmark):
     # unset num_tasks_per_node from the hpctestlib.
     num_tasks_per_node = None
 
+    # Set num_warmup_iters to 5 to reduce execution time, especially on slower interconnects
+    num_warmup_iters = 5
+    # Set num_iters to 10 to reduce execution time, especially on slower interconnects
+    num_iters = 10
+
     @run_after('init')
     def filter_scales_2gpus(self):
         """Filter out scales with < 2 GPUs if running on GPUs"""
@@ -168,6 +173,11 @@ class EESSI_OSU_Micro_Benchmarks_coll(osu_benchmark):
     device_type = parameter([DEVICE_TYPES[CPU], DEVICE_TYPES[GPU]])
     # Unset num_tasks_per_node from hpctestlib
     num_tasks_per_node = None
+
+    # Set num_warmup_iters to 5 to reduce execution time, especially on slower interconnects
+    num_warmup_iters = 5
+    # Set num_iters to 10 to reduce execution time, especially on slower interconnects
+    num_iters = 10
 
     @run_after('init')
     def run_after_init(self):


### PR DESCRIPTION
Tests on e.g. the AWS Magic Castle cluster have been pretty slow, especially the collectives that send a ton of data around. A thousand iterations is definitely overkill, we don't generally need that kind of precision to see when something is wrong. 

An example run with `--reruns=5` and only the bandwidth test for one of the modules produced:

```
[----------] start processing checks
[ RUN      ] EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
[       OK ] (1/1) EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
P: bandwidth: 28178.61 MB/s (r:0, l:None, u:None)
[----------] all spawned checks have finished

[----------] start processing checks
[ RUN      ] EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
[       OK ] (1/1) EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
P: bandwidth: 28175.13 MB/s (r:0, l:None, u:None)
[----------] all spawned checks have finished

[----------] start processing checks
[ RUN      ] EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
[       OK ] (1/1) EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
P: bandwidth: 28173.91 MB/s (r:0, l:None, u:None)
[----------] all spawned checks have finished

[----------] start processing checks
[ RUN      ] EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
[       OK ] (1/1) EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
P: bandwidth: 28175.5 MB/s (r:0, l:None, u:None)
[----------] all spawned checks have finished

[----------] start processing checks
[ RUN      ] EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
[       OK ] (1/1) EESSI_OSU_Micro_Benchmarks_pt2pt %benchmark_info=mpi.pt2pt.osu_bw %scale=2_nodes %module_name=OSU-Micro-Benchmarks/7.2-gompi-2023b %device_type=cpu /f749ec9f @snellius:genoa+default
P: bandwidth: 28170.4 MB/s (r:0, l:None, u:None)
[----------] all spawned checks have finished
```

That shows reproducibility is just fine with the current iteration count.

Sure, on interconnects with larger overbooking, you will probably see more variation - but that's a realistic representation of performance of a shared resource. Not necessarily a problem. 