### PR TITLE
bump version to 0.2.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,7 +1,7 @@
 This file contains a description of the major changes to the EESSI test suite.
 For more detailed information, please see the git log.
 
-v0.2.0 (7 march 2024)
+v0.2.0 (7 March 2024)
 ---------------------
 
 This is a minor release of the EESSI test-suite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eessi-testsuite"
-version = "0.1.0"
+version = "0.2.0"
 description = "Test suite for the EESSI software stack"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = eessi-testsuite
-version = 0.1.0
+version = 0.2.0
 description = Test suite for the EESSI software stack
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Version bump is missing in tagged release https://github.com/EESSI/test-suite/releases/tag/v0.2.0, fixing that here...

We should add a checklist of things to do when making a release somewhere, in the README file I guess.