### PR TITLE
Change behavior for `assign_tasks_per_compute_unit(test, COMPUTE_UNIT[CPU])` on hyperthreading-enabled systems + use compat process binding in ESPResSo test

### DIFF
--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -4,6 +4,7 @@ Constants for ReFrame tests
 
 AMD = 'AMD'
 CI = 'CI'
+HWTHREAD = 'HWTHREAD'
 CPU = 'CPU'
 CPU_SOCKET = 'CPU_SOCKET'
 GPU = 'GPU'
@@ -19,6 +20,7 @@ DEVICE_TYPES = {
 }
 
 COMPUTE_UNIT = {
+    HWTHREAD: 'hwthread',
     CPU: 'cpu',
     CPU_SOCKET: 'cpu_socket',
     GPU: 'gpu',

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -241,7 +241,7 @@ def _assign_one_task_per_cpu(test: rfm.RegressionTest):
     # neither num_tasks_per_node nor num_cpus_per_task are set
     if not test.num_tasks_per_node and not test.num_cpus_per_task:
         check_proc_attribute_defined(test, 'num_cpus_per_core')
-        test.num_tasks_per_node = min(
+        test.num_tasks_per_node = max(
             int(test.default_num_cpus_per_node / test.current_partition.processor.num_cpus_per_core),
             1
         )

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -241,8 +241,9 @@ def _assign_one_task_per_cpu(test: rfm.RegressionTest):
     # neither num_tasks_per_node nor num_cpus_per_task are set
     if not test.num_tasks_per_node and not test.num_cpus_per_task:
         check_proc_attribute_defined(test, 'num_cpus_per_core')
-        test.num_tasks_per_node = int(
-            test.default_num_cpus_per_node / test.current_partition.processor.num_cpus_per_core
+        test.num_tasks_per_node = min(
+            int(test.default_num_cpus_per_node / test.current_partition.processor.num_cpus_per_core),
+            1
         )
         test.num_cpus_per_task = int(test.default_num_cpus_per_node / test.num_tasks_per_node)
 

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -108,7 +108,9 @@ def assign_tasks_per_compute_unit(test: rfm.RegressionTest, compute_unit: str, n
     if SCALES[test.scale].get('num_cpus_per_node') is not None and compute_unit != COMPUTE_UNIT[HWTHREAD]:
         check_proc_attribute_defined(test, 'num_cpus_per_core')
         num_cpus_per_core = test.current_partition.processor.num_cpus_per_core
-        test.default_num_cpus_per_node = test.default_num_cpus_per_node * num_cpus_per_core
+        # On a hyperthreading system?
+        if num_cpus_per_core > 1:
+            test.default_num_cpus_per_node = test.default_num_cpus_per_node * num_cpus_per_core
 
     if FEATURES[GPU] in test.current_partition.features:
         _assign_default_num_gpus_per_node(test)

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -66,20 +66,18 @@ def assign_tasks_per_compute_unit(test: rfm.RegressionTest, compute_unit: str, n
     Total task count is determined based on the number of nodes to be used in the test.
     Behaviour of this function is (usually) sensible for MPI tests.
 
+    WARNING: when using COMPUTE_UNIT[HWTHREAD] and invoking a hook for process binding, please verify that process binding happens correctly
+
     Arguments:
     - test: the ReFrame test to which this hook should apply
     - compute_unit: a device as listed in eessi.testsuite.constants.COMPUTE_UNIT
 
     Examples:
     On a single node with 2 sockets, 64 cores and 128 hyperthreads:
-    - assign_tasks_per_compute_unit(test, COMPUTE_UNIT[CPU]) will launch 64 tasks with 1 thread
-    - assign_tasks_per_compute_unit(test, COMPUTE_UNIT[CPU_SOCKET]) will launch 2 tasks with 32 threads per task
+    - assign_tasks_per_compute_unit(test, COMPUTE_UNIT[HWTHREAD]) will launch 128 tasks with 1 thread per task
+    - assign_tasks_per_compute_unit(test, COMPUTE_UNIT[CPU]) will launch 64 tasks with 2 threads per task
+    - assign_tasks_per_compute_unit(test, COMPUTE_UNIT[CPU_SOCKET]) will launch 2 tasks with 64 threads per task
 
-    Future work:
-    Currently, on a single node with 2 sockets, 64 cores and 128 hyperthreads, this
-    - assign_one_task_per_compute_unit(test, COMPUTE_UNIT[CPU], true) launches 128 tasks with 1 thread
-    - assign_one_task_per_compute_unit(test, COMPUTE_UNIT[CPU_SOCKET], true) launches 2 tasks with 64 threads per task
-    In the future, we'd like to add an arugment that disables spawning tasks for hyperthreads.
     """
     if num_per != 1 and compute_unit in [COMPUTE_UNIT[GPU], COMPUTE_UNIT[CPU], COMPUTE_UNIT[CPU_SOCKET]]:
         raise NotImplementedError(
@@ -106,6 +104,8 @@ def assign_tasks_per_compute_unit(test: rfm.RegressionTest, compute_unit: str, n
 
     if compute_unit == COMPUTE_UNIT[GPU]:
         _assign_one_task_per_gpu(test)
+    elif compute_unit == COMPUTE_UNIT[HWTHREAD]:
+        _assign_one_task_per_hwthread(test)
     elif compute_unit == COMPUTE_UNIT[CPU]:
         _assign_one_task_per_cpu(test)
     elif compute_unit == COMPUTE_UNIT[CPU_SOCKET]:
@@ -217,6 +217,41 @@ def _assign_one_task_per_cpu_socket(test: rfm.RegressionTest):
 
 
 def _assign_one_task_per_cpu(test: rfm.RegressionTest):
+    """
+    Sets num_tasks_per_node and num_cpus_per_task such that it will run one task per core,
+    unless specified with:
+    --setvar num_tasks_per_node=<x> and/or
+    --setvar num_cpus_per_task=<y>.
+
+    Default resources requested:
+    - num_tasks_per_node = default_num_cpus_per_node
+    - num_cpus_per_task = default_num_cpus_per_node / num_tasks_per_node
+    """
+    # neither num_tasks_per_node nor num_cpus_per_task are set
+    if not test.num_tasks_per_node and not test.num_cpus_per_task:
+        check_proc_attribute_defined(test, 'num_cpus_per_core')
+        test.num_tasks_per_node = int(test.default_num_cpus_per_node / test.current_partition.processor.num_cpus_per_core)
+        test.num_cpus_per_task = int(test.default_num_cpus_per_node / test.num_tasks_per_node)
+
+    # num_tasks_per_node is not set, but num_cpus_per_task is
+    elif not test.num_tasks_per_node:
+        test.num_tasks_per_node = int(test.default_num_cpus_per_node / test.num_cpus_per_task)
+
+    # num_cpus_per_task is not set, but num_tasks_per_node is
+    elif not test.num_cpus_per_task:
+        test.num_cpus_per_task = int(test.default_num_cpus_per_node / test.num_tasks_per_node)
+
+    else:
+        pass  # both num_tasks_per_node and num_cpus_per_node are already set
+
+    test.num_tasks = test.num_nodes * test.num_tasks_per_node
+
+    log(f'num_tasks_per_node set to {test.num_tasks_per_node}')
+    log(f'num_cpus_per_task set to {test.num_cpus_per_task}')
+    log(f'num_tasks set to {test.num_tasks}')
+
+
+def _assign_one_task_per_hwthread(test: rfm.RegressionTest):
     """
     Sets num_tasks_per_node and num_cpus_per_task such that it will run one task per core,
     unless specified with:
@@ -508,6 +543,10 @@ def set_compact_process_binding(test: rfm.RegressionTest):
     This hook sets a binding policy for process binding.
     More specifically, it will bind each process to subsequent domains of test.num_cpus_per_task cores.
 
+    Arguments:
+    - test: the ReFrame test to which this hook should apply
+
+
     A few examples:
     - Pure MPI (test.num_cpus_per_task = 1) will result in binding 1 process to each core.
       this will happen in a compact way, i.e. rank 0 to core 0, rank 1 to core 1, etc
@@ -522,6 +561,7 @@ def set_compact_process_binding(test: rfm.RegressionTest):
 
     # Check if hyperthreading is enabled. If so, divide the number of cpus per task by the number
     # of hw threads per core to get a physical core count
+    # TODO: check if this also leads to sensible binding when using COMPUTE_UNIT[HWTHREAD]
     check_proc_attribute_defined(test, 'num_cpus_per_core')
     num_cpus_per_core = test.current_partition.processor.num_cpus_per_core
     physical_cpus_per_task = int(test.num_cpus_per_task / num_cpus_per_core)

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -66,7 +66,8 @@ def assign_tasks_per_compute_unit(test: rfm.RegressionTest, compute_unit: str, n
     Total task count is determined based on the number of nodes to be used in the test.
     Behaviour of this function is (usually) sensible for MPI tests.
 
-    WARNING: when using COMPUTE_UNIT[HWTHREAD] and invoking a hook for process binding, please verify that process binding happens correctly
+    WARNING: when using COMPUTE_UNIT[HWTHREAD] and invoking a hook for process binding, please verify that process
+    binding happens correctly.
 
     Arguments:
     - test: the ReFrame test to which this hook should apply
@@ -230,7 +231,9 @@ def _assign_one_task_per_cpu(test: rfm.RegressionTest):
     # neither num_tasks_per_node nor num_cpus_per_task are set
     if not test.num_tasks_per_node and not test.num_cpus_per_task:
         check_proc_attribute_defined(test, 'num_cpus_per_core')
-        test.num_tasks_per_node = int(test.default_num_cpus_per_node / test.current_partition.processor.num_cpus_per_core)
+        test.num_tasks_per_node = int(
+            test.default_num_cpus_per_node / test.current_partition.processor.num_cpus_per_core
+        )
         test.num_cpus_per_task = int(test.default_num_cpus_per_node / test.num_tasks_per_node)
 
     # num_tasks_per_node is not set, but num_cpus_per_task is

--- a/eessi/testsuite/tests/apps/espresso/espresso.py
+++ b/eessi/testsuite/tests/apps/espresso/espresso.py
@@ -65,6 +65,10 @@ class EESSI_ESPRESSO(rfm.RunOnlyRegressionTest):
         mem_required_per_node = self.num_tasks_per_node * 0.9
         hooks.req_memory_per_node(test=self, app_mem_req=mem_required_per_node * 1024)
 
+    @run_after('setup')
+    def set_binding(self):
+        hooks.set_compact_process_binding(self)
+
     @deferrable
     def assert_completion(self):
         '''Check completion'''


### PR DESCRIPTION
Change behavior on systems that have hyperthreading enabled for the `assign_tasks_per_compute_unit(test, COMPUTE_UNIT[CPU]) hook`. Previous behavior is that this launches one 1 task per hardware thread. We now change that to launch one task per physical core. A new COMPUTE_UNIT is introduced (COMPUTE_UNIT[HWTHREAD]) in case one wants to retain the previous behavior of launching one task per hardware thread.