### PR TITLE
make EESSI optional in common_eessi_init

### DIFF
--- a/config/aws_citc.py
+++ b/config/aws_citc.py
@@ -224,7 +224,7 @@ partition_defaults = {
         FEATURES['CPU']
     ],
     'prepare_cmds': [
-        'source %s' % common_eessi_init(),
+        common_eessi_init(),
         # Required when using srun as launcher with --export=NONE in partition access, in order to ensure job
         # steps inherit environment. It doesn't hurt to define this even if srun is not used
         'export SLURM_EXPORT_ENV=ALL'

--- a/config/aws_mc.py
+++ b/config/aws_mc.py
@@ -100,7 +100,7 @@ partition_defaults = {
         FEATURES['CPU']
     ] + list(SCALES.keys()),
     'prepare_cmds': [
-        'source %s' % common_eessi_init(),
+        common_eessi_init(),
         # Required when using srun as launcher with --export=NONE in partition access, in order to ensure job
         # steps inherit environment. It doesn't hurt to define this even if srun is not used
         'export SLURM_EXPORT_ENV=ALL'

--- a/config/it4i_karolina.py
+++ b/config/it4i_karolina.py
@@ -36,7 +36,7 @@ site_configuration = {
                     'name': 'qcpu',
                     'scheduler': 'slurm',
                     'prepare_cmds': [
-                        'source %s' % common_eessi_init(),
+                        common_eessi_init(),
                         # Pass job environment variables like $PATH, etc., into job steps
                         'export SLURM_EXPORT_ENV=ALL',
                         # Needed when using srun launcher
@@ -71,7 +71,7 @@ site_configuration = {
                 #     'name': 'qgpu',
                 #     'scheduler': 'slurm',
                 #     'prepare_cmds': [
-                #         'source %s' % common_eessi_init(),
+                #         common_eessi_init(),
                 #         # Pass job environment variables like $PATH, etc., into job steps
                 #         'export SLURM_EXPORT_ENV=ALL',
                 #         # Needed when using srun launcher

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -36,7 +36,7 @@ site_configuration = {
                     'name': 'cpu',
                     'scheduler': 'slurm',
                     'prepare_cmds': [
-                        'source %s' % common_eessi_init(),
+                        common_eessi_init(),
                         # Pass job environment variables like $PATH, etc., into job steps
                         'export SLURM_EXPORT_ENV=ALL',
                         # Needed when using srun launcher
@@ -72,7 +72,7 @@ site_configuration = {
                 #     'name': 'gpu',
                 #     'scheduler': 'slurm',
                 #     'prepare_cmds': [
-                #         'source %s' % common_eessi_init(),
+                #         common_eessi_init(),
                 #         # Pass job environment variables like $PATH, etc., into job steps
                 #         'export SLURM_EXPORT_ENV=ALL',
                 #         # Needed when using srun launcher

--- a/config/macc_deucalion.py
+++ b/config/macc_deucalion.py
@@ -25,7 +25,7 @@ site_configuration = {
                         # bypass CPU autodetection for now aarch64/a64fx,
                         # see https://github.com/EESSI/software-layer/pull/608
                         'export EESSI_SOFTWARE_SUBDIR_OVERRIDE=aarch64/a64fx',
-                        'source %s' % common_eessi_init(),
+                        common_eessi_init(),
                         # Pass job environment variables like $PATH, etc., into job steps
                         'export SLURM_EXPORT_ENV=HOME,PATH,LD_LIBRARY_PATH,PYTHONPATH',
                     ],

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -39,7 +39,7 @@ site_configuration = {
                 {
                     'name': 'rome',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': [common_eessi_init()],
                     'launcher': 'mpirun',
                     'access': ['-p rome', '--export=None'],
                     'environs': ['default'],
@@ -63,7 +63,7 @@ site_configuration = {
                 {
                     'name': 'genoa',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': [common_eessi_init()],
                     'launcher': 'mpirun',
                     'access': ['-p genoa', '--export=None'],
                     'environs': ['default'],
@@ -87,7 +87,7 @@ site_configuration = {
                 {
                     'name': 'gpu_A100',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': [common_eessi_init()],
                     'launcher': 'mpirun',
                     'access': ['-p gpu_a100', '--export=None'],
                     'environs': ['default'],
@@ -123,7 +123,7 @@ site_configuration = {
                 {
                     'name': 'gpu_H100',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': [common_eessi_init()],
                     'launcher': 'mpirun',
                     'access': ['-p gpu_h100', '--export=None'],
                     'environs': ['default'],

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -33,7 +33,7 @@ site_configuration = {
                 {
                     'name': 'cpu_rome_256gb',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': common_eessi_init(),
                     'access': hortense_access + ['--partition=cpu_rome'],
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Rome, 256GiB RAM)',
@@ -65,7 +65,7 @@ site_configuration = {
                 {
                     'name': 'cpu_rome_512gb',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': common_eessi_init(),
                     'access': hortense_access + ['--partition=cpu_rome_512'],
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Rome, 512GiB RAM)',
@@ -97,7 +97,7 @@ site_configuration = {
                 {
                     'name': 'cpu_milan',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': common_eessi_init(),
                     'access': hortense_access + ['--partition=cpu_milan'],
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Milan, 256GiB RAM)',
@@ -129,7 +129,7 @@ site_configuration = {
                 {
                     'name': 'gpu_rome_a100_40gb',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': common_eessi_init(),
                     'access': hortense_access + ['--partition=gpu_rome_a100_40'],
                     'environs': ['default'],
                     'descr': 'GPU nodes (A100 40GB)',
@@ -173,7 +173,7 @@ site_configuration = {
                 {
                     'name': 'gpu_rome_a100_80gb',
                     'scheduler': 'slurm',
-                    'prepare_cmds': ['source %s' % common_eessi_init()],
+                    'prepare_cmds': common_eessi_init(),
                     'access': hortense_access + ['--partition=gpu_rome_a100_80'],
                     'environs': ['default'],
                     'descr': 'GPU nodes (A100 80GB)',

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -33,7 +33,7 @@ site_configuration = {
                 {
                     'name': 'cpu_rome_256gb',
                     'scheduler': 'slurm',
-                    'prepare_cmds': common_eessi_init(),
+                    'prepare_cmds': [common_eessi_init()],
                     'access': hortense_access + ['--partition=cpu_rome'],
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Rome, 256GiB RAM)',
@@ -65,7 +65,7 @@ site_configuration = {
                 {
                     'name': 'cpu_rome_512gb',
                     'scheduler': 'slurm',
-                    'prepare_cmds': common_eessi_init(),
+                    'prepare_cmds': [common_eessi_init()],
                     'access': hortense_access + ['--partition=cpu_rome_512'],
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Rome, 512GiB RAM)',
@@ -97,7 +97,7 @@ site_configuration = {
                 {
                     'name': 'cpu_milan',
                     'scheduler': 'slurm',
-                    'prepare_cmds': common_eessi_init(),
+                    'prepare_cmds': [common_eessi_init()],
                     'access': hortense_access + ['--partition=cpu_milan'],
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Milan, 256GiB RAM)',
@@ -129,7 +129,7 @@ site_configuration = {
                 {
                     'name': 'gpu_rome_a100_40gb',
                     'scheduler': 'slurm',
-                    'prepare_cmds': common_eessi_init(),
+                    'prepare_cmds': [common_eessi_init()],
                     'access': hortense_access + ['--partition=gpu_rome_a100_40'],
                     'environs': ['default'],
                     'descr': 'GPU nodes (A100 40GB)',
@@ -173,7 +173,7 @@ site_configuration = {
                 {
                     'name': 'gpu_rome_a100_80gb',
                     'scheduler': 'slurm',
-                    'prepare_cmds': common_eessi_init(),
+                    'prepare_cmds': [common_eessi_init()],
                     'access': hortense_access + ['--partition=gpu_rome_a100_80'],
                     'environs': ['default'],
                     'descr': 'GPU nodes (A100 80GB)',

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -96,12 +96,19 @@ def common_eessi_init(eessi_version=None):
     eessi_cvmfs_repo = os.getenv('EESSI_CVMFS_REPO', None)
 
     if eessi_cvmfs_repo is None:
-        warn_msg = "Environment variable 'EESSI_CVMFS_REPO' was not found."
-        warn_msg += " To use EESSI modules, initialize the EESSI environment before running the test suite."
+        warn_msg = '\n' + '\n'.join([
+            "EESSI WARNING: Environment variable 'EESSI_CVMFS_REPO' was not found.",
+            "EESSI WARNING: If you do not intend to use the EESSI software stack, this is perfectly fine.",
+            "EESSI WARNING: To use EESSI, initialize the EESSI environment before running the test suite.",
+        ])
         warnings.warn(warn_msg)
-        return []
+        return ''
 
-    if eessi_cvmfs_repo == '/cvmfs/pilot.eessi-hpc.org':
+    eessi_init = []
+    pilot_repo = '/cvmfs/pilot.eessi-hpc.org'
+
+    if eessi_cvmfs_repo == pilot_repo:
+        eessi_init.append('export EESSI_FORCE_PILOT=1')
         if eessi_version is None:
             # Try also EESSI_VERSION for backwards compatibility with previous common_eessi_init implementation
             eessi_version = os.getenv('EESSI_PILOT_VERSION', os.getenv('EESSI_VERSION', 'latest'))
@@ -116,7 +123,10 @@ def common_eessi_init(eessi_version=None):
             err_msg += " Did you initialize the EESSI environment before running the test suite?"
             raise ValueError(err_msg)
 
-    if eessi_cvmfs_repo == '/cvmfs/pilot.eessi-hpc.org' and eessi_version == 'latest':
-        return ['source /cvmfs/pilot.eessi-hpc.org/latest/init/bash']
+    if eessi_cvmfs_repo == pilot_repo and eessi_version == 'latest':
+        version_string = eessi_version
     else:
-        return [f'{eessi_cvmfs_repo}/versions/{eessi_version}/init/bash']
+        version_string = f'versions/{eessi_version}'
+
+    eessi_init.append(f'source {eessi_cvmfs_repo}/{version_string}/init/bash')
+    return ' && '.join(eessi_init)

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -96,7 +96,7 @@ def common_eessi_init(eessi_version=None):
     eessi_cvmfs_repo = os.getenv('EESSI_CVMFS_REPO', None)
 
     if eessi_cvmfs_repo is None:
-        warn_msg = "Environment variable 'EESSI_CVMFS_REPO' was not found; using local modules only."
+        warn_msg = "Environment variable 'EESSI_CVMFS_REPO' was not found."
         warn_msg += " To use EESSI modules, initialize the EESSI environment before running the test suite."
         warnings.warn(warn_msg)
         return []

--- a/eessi/testsuite/common_config.py
+++ b/eessi/testsuite/common_config.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 perflog_format = '|'.join([
     '%(check_job_completion_time)s',
@@ -93,10 +94,13 @@ def common_eessi_init(eessi_version=None):
     """
     # Check which EESSI_CVMFS_REPO we are running under
     eessi_cvmfs_repo = os.getenv('EESSI_CVMFS_REPO', None)
+
     if eessi_cvmfs_repo is None:
-        err_msg = "Environment variable 'EESSI_CVMFS_REPO' was not found."
-        err_msg += " Did you initialize the EESSI environment before running the test suite?"
-        raise ValueError(err_msg)
+        warn_msg = "Environment variable 'EESSI_CVMFS_REPO' was not found; using local modules only."
+        warn_msg += " To use EESSI modules, initialize the EESSI environment before running the test suite."
+        warnings.warn(warn_msg)
+        return []
+
     if eessi_cvmfs_repo == '/cvmfs/pilot.eessi-hpc.org':
         if eessi_version is None:
             # Try also EESSI_VERSION for backwards compatibility with previous common_eessi_init implementation
@@ -113,6 +117,6 @@ def common_eessi_init(eessi_version=None):
             raise ValueError(err_msg)
 
     if eessi_cvmfs_repo == '/cvmfs/pilot.eessi-hpc.org' and eessi_version == 'latest':
-        return '/cvmfs/pilot.eessi-hpc.org/latest/init/bash'
+        return ['source /cvmfs/pilot.eessi-hpc.org/latest/init/bash']
     else:
-        return '%s/versions/%s/init/bash' % (eessi_cvmfs_repo, eessi_version)
+        return [f'{eessi_cvmfs_repo}/versions/{eessi_version}/init/bash']


### PR DESCRIPTION
this change allows using either the local modules or EESSI using a single config file.
if `EESSI_CVMFS_REPO` envvar is defined, use EESSI, else use local modules (or from other sources).

EDIT: all config files are now updated