### PR TITLE
Specify memory as an extra resource in all configs

### DIFF
--- a/config/aws_mc.py
+++ b/config/aws_mc.py
@@ -105,6 +105,12 @@ partition_defaults = {
         # steps inherit environment. It doesn't hurt to define this even if srun is not used
         'export SLURM_EXPORT_ENV=ALL'
     ],
+    'resources': [
+        {
+            'name': 'memory',
+            'options': ['--mem={size}'],
+        }
+    ],
     'extras': {
         # Node types have somewhat varying amounts of memory, but we'll make it easy on ourselves
         # All should _at least_ have this amount (30GB * 1E9 / (1024*1024) = 28610 MiB)

--- a/config/azure_mc.py
+++ b/config/azure_mc.py
@@ -90,6 +90,12 @@ partition_defaults = {
     'features': [
         FEATURES['CPU']
     ] + list(SCALES.keys()),
+    'resources': [
+        {
+            'name': 'memory',
+            'options': ['--mem={size}'],
+        }
+    ],
 }
 for system in site_configuration['systems']:
     for partition in system['partitions']:

--- a/config/it4i_karolina.py
+++ b/config/it4i_karolina.py
@@ -60,6 +60,12 @@ site_configuration = {
                     'features': [
                         FEATURES[CPU],
                     ] + list(SCALES.keys()),
+                    'resources': [
+                        {
+                            'name': 'memory',
+                            'options': ['--mem={size}'],
+                        }
+                    ],
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -56,6 +56,11 @@ site_configuration = {
                             'options': ['--mem={size}'],
                         }
                     ],
+                    'extras': {
+                        # Make sure to round down, otherwise a job might ask for more mem than is available
+                        # per node
+                        'mem_per_node': 229376  # in MiB
+                    },
                     # list(SCALES.keys()) adds all the scales from eessi.testsuite.constants as valid for thi partition
                     # Can be modified if not all scales can run on this partition, see e.g. the surf_snellius.py config
                     'features': [FEATURES[CPU]] + list(SCALES.keys()),
@@ -87,6 +92,11 @@ site_configuration = {
                             'options': ['--mem={size}'],
                         }
                     ],
+                    'extras': {
+                        # Make sure to round down, otherwise a job might ask for more mem than is available
+                        # per node
+                        'mem_per_node': 229376  # in MiB
+                    },
                     'devices': [
                         {
                             'type': DEVICE_TYPES[GPU],


### PR DESCRIPTION
Make sure that we set 'memory' as resource in all configs. This needs to be specified in order for memory to be requested by the hook