### PR TITLE
Fix CI for new ReFrame 4.6.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,6 @@ jobs:
             # update $PYTHONPATH so 'import eessi.testsuite.utils' works
             export PYTHONPATH=$PWD:$PYTHONPATH
             echo $PYTHONPATH
-            python -c 'import eessi.testsuite.utils'
 
             # show active ReFrame configuration,
             # enable verbose output to help expose problems with configuration file (if any)


### PR DESCRIPTION
ReFrame 4.6.2 got deployed in EESSI, and is now picked up by the CI. The module is different in that the `external` folder within the ReFrame installation prefix is no longer on the `PYTHONPATH`. As a result, `python -c "import reframe"` doesn't work anymore - and note that this is by design. One should never import ReFrame directly, but only _in a ReFrame test_ that is run by the `reframe` command. The `reframe` command then adds the `external` folder to the `sys.path`. The advantage of this setup is that _only_ ReFrame picks up on those python deps in `external` folder, it doesn't polute the `PYTHONPATH`.

This PR removes the line that does `python -c 'import eessi.testsuite.utils'`, since that is _not_ supposed to work: it indirectly imports `reframe`, which is not supposed to work, as explained before.