### PR TITLE
Use ReFrame generated topology for hortense cpu partitions

### DIFF
--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -1,7 +1,23 @@
 # ReFrame configuration file for VSC Tier-1 Hortense
 # https://docs.vscentrum.be/en/latest/gent/tier1_hortense.html
 #
-# authors: Samuel Moors (VUB-HPC), Kenneth Hoste (HPC-UGent)
+# authors: Samuel Moors (VUB-HPC), Kenneth Hoste (HPC-UGent), Lara Peeters (HPC-UGent)
+
+# Use generated topology file by ReFrame for CPU partitions
+# Cannot use autodetection untill `sched_options` is part of the ReFrame release https://github.com/reframe-hpc/reframe/issues/2970
+
+# Instructions on generating topology file
+# ```
+#    module swap cluster/{partition}
+#    qsub -l nodes=1:ppn=all -l walltime=00:30:00
+#
+#    python3 -m venv "$TMPDIR"/reframe_venv
+#    source "$TMPDIR"/reframe_venv/bin/activate
+#    python3 -m pip install --upgrade pip
+#    python3 -m pip install reframe-hpc=="4.6.2"
+#
+#    reframe --detect-host-topology /dodrio/scratch/users/vsc46128/.reframe/topology/hortense-{partition_name}/processor.json
+# ```
 
 from reframe.core.backends import register_launcher
 from reframe.core.launchers import JobLauncher
@@ -39,13 +55,6 @@ site_configuration = {
                     'max_jobs': 20,
                     'launcher': 'mympirun',
                     'modules': ['vsc-mympirun'],
-                    'processor': {
-                        'num_cpus': 128,
-                        'num_sockets': 2,
-                        'num_cpus_per_socket': 64,
-                        'num_cpus_per_core': 1,
-                        'arch': 'zen2',
-                    },
                     'resources': [
                         {
                             'name': 'memory',
@@ -71,13 +80,6 @@ site_configuration = {
                     'max_jobs': 20,
                     'launcher': 'mympirun',
                     'modules': ['vsc-mympirun'],
-                    'processor': {
-                        'num_cpus': 128,
-                        'num_sockets': 2,
-                        'num_cpus_per_socket': 64,
-                        'num_cpus_per_core': 1,
-                        'arch': 'zen2',
-                    },
                     'resources': [
                         {
                             'name': 'memory',
@@ -103,13 +105,6 @@ site_configuration = {
                     'max_jobs': 20,
                     'launcher': 'mympirun',
                     'modules': ['vsc-mympirun'],
-                    'processor': {
-                        'num_cpus': 128,
-                        'num_sockets': 2,
-                        'num_cpus_per_socket': 64,
-                        'num_cpus_per_core': 1,
-                        'arch': 'zen3',
-                    },
                     'resources': [
                         {
                             'name': 'memory',


### PR DESCRIPTION
The tests of PyCharm currently fail because of missing information of the processor. So using `reframe --detect-host-topology` is a better way forward until `sched_options` becomes part of the ReFrame release.