### PR TITLE
Fix hostnames in config

### DIFF
--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -34,7 +34,7 @@ site_configuration = {
             'modules_system': 'lmod',
             # Just accept any hostname. List of hostnames can only get outdated, and this is a single-system config
             # file anyway.
-            'hostnames': ['*'],
+            'hostnames': ['.*'],
             'prefix': reframe_prefix,
             'stagedir': f'/scratch-shared/{os.environ.get("USER")}/reframe_output/staging',
             'partitions': [


### PR DESCRIPTION
Previous PR was wrong: it should be a regex, so `.*`, instead of `*`. The latter causes an error ("nothing to repeat").
Fixed with this PR.