### PR TITLE
Limit azure aws jobs 1 per partition

### DIFF
--- a/config/aws_mc.py
+++ b/config/aws_mc.py
@@ -116,6 +116,7 @@ partition_defaults = {
         # All should _at least_ have this amount (30GB * 1E9 / (1024*1024) = 28610 MiB)
         'mem_per_node': 28610
     },
+    'max_jobs': 1,
 }
 for system in site_configuration['systems']:
     for partition in system['partitions']:

--- a/config/azure_mc.py
+++ b/config/azure_mc.py
@@ -100,6 +100,7 @@ partition_defaults = {
             'options': ['--mem={size}'],
         }
     ],
+    'max_jobs': 1,
 }
 for system in site_configuration['systems']:
     for partition in system['partitions']:


### PR DESCRIPTION
This PR limits the number of jobs to 1 per partition for the AWS and Azure clusters. This doesn't prevent the issue of crossing the vCPU threshold, but should at least alleviate it. 