### PR TITLE
Collect addional info in mixin

### DIFF
--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -191,28 +191,17 @@ class EESSI_Mixin(RegressionMixin):
     def extract_runtime_info_from_log(self):
         """Extracts the printed runtime info from the job log and logs it as reframe variables"""
         # If EESSI_CVMFS_REPO environment variable was set, extract it and store it in self.cvmfs_repo_name
-        # Try block is needed to suppress sanity error if there is no match
-        try:
-            repo_name = sn.extractsingle(r'EESSI_CVMFS_REPO: /cvmfs/(?P<repo>.*)$', f'{self.stagedir}/{self.stdout}',
-                                         'repo', str)
-            if repo_name:
-                self.cvmfs_repo_name = f'{repo_name}'
-        except SanityError:
-            pass
+        repo_name = sn.extractall(r'EESSI_CVMFS_REPO: /cvmfs/(?P<repo>.*)$', f'{self.stagedir}/{self.stdout}',
+                                  'repo', str)
+        if repo_name:
+            self.cvmfs_repo_name = f'{repo_name}'
 
-        try:
-            software_subdir = sn.extractsingle(r'EESSI_SOFTWARE_SUBDIR: (?P<subdir>.*)$',
+        software_subdir = sn.extractall(r'EESSI_SOFTWARE_SUBDIR: (?P<subdir>.*)$',
                                                f'{self.stagedir}/{self.stdout}', 'subdir', str)
-            if software_subdir:
-                self.cvmfs_software_subdir = f'{software_subdir}'
-        except SanityError:
-            pass
+        if software_subdir:
+            self.cvmfs_software_subdir = f'{software_subdir}'
 
-        try:
-            module_path = sn.extractsingle(r'FULL_MODULEPATH: (?P<modpath>.*)$', f'{self.stagedir}/{self.stdout}',
+        module_path = sn.extractall(r'FULL_MODULEPATH: (?P<modpath>.*)$', f'{self.stagedir}/{self.stdout}',
                                            'modpath', str)
-            print(f"Full modulepath: {module_path}")
-            if module_path:
-                self.full_modulepath = f'{module_path}'
-        except SanityError:
-            pass
+        if module_path:
+            self.full_modulepath = f'{module_path}'

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -9,6 +9,7 @@ from eessi.testsuite.constants import DEVICE_TYPES, SCALES, COMPUTE_UNIT, TAGS
 from eessi.testsuite.utils import log
 from eessi.testsuite import __version__ as testsuite_version
 
+
 # Hooks from the Mixin class seem to be executed _before_ those of the child class
 # Thus, if the Mixin class needs self.X to be defined in after setup, the child class would have to define it before
 # setup. That's a disadvantage and might not always be possible - let's see how far we get. It also seems that,
@@ -194,7 +195,8 @@ class EESSI_Mixin(RegressionMixin):
         # If EESSI_CVMFS_REPO environment variable was set, extract it and store it in self.cvmfs_repo_name
         # Try block is needed to surpress sanity error if there is no match
         try:
-            repo_name = sn.extractsingle(r'EESSI_CVMFS_REPO: /cvmfs/(?P<repo>.*)$', f'{self.stagedir}/{self.stdout}', 'repo', str)
+            repo_name = sn.extractsingle(r'EESSI_CVMFS_REPO: /cvmfs/(?P<repo>.*)$', f'{self.stagedir}/{self.stdout}',
+                                         'repo', str)
             if repo_name:
                 self.cvmfs_repo_name = f'{repo_name}'
         except SanityError:

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -190,6 +190,9 @@ class EESSI_Mixin(RegressionMixin):
     @run_after('run')
     def extract_runtime_info_from_log(self):
         """Extracts the printed runtime info from the job log and logs it as reframe variables"""
+        if self.is_dry_run():
+            return
+
         # If EESSI_CVMFS_REPO environment variable was set, extract it and store it in self.cvmfs_repo_name
         repo_name = sn.extractall(r'EESSI_CVMFS_REPO: /cvmfs/(?P<repo>.*)$', f'{self.stagedir}/{self.stdout}',
                                   'repo', str)

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -1,12 +1,13 @@
 from reframe.core.builtins import parameter, run_after, variable
-from reframe.core.exceptions import ReframeFatalError
+from reframe.core.exceptions import ReframeFatalError, SanityError
 from reframe.core.pipeline import RegressionMixin
 from reframe.utility.sanity import make_performance_function
+import reframe.utility.sanity as sn
 
 from eessi.testsuite import hooks
 from eessi.testsuite.constants import DEVICE_TYPES, SCALES, COMPUTE_UNIT, TAGS
 from eessi.testsuite.utils import log
-
+from eessi.testsuite import __version__ as testsuite_version
 
 # Hooks from the Mixin class seem to be executed _before_ those of the child class
 # Thus, if the Mixin class needs self.X to be defined in after setup, the child class would have to define it before
@@ -41,6 +42,14 @@ class EESSI_Mixin(RegressionMixin):
     scale = parameter(SCALES.keys())
     bench_name = None
     bench_name_ci = None
+
+    # Create ReFrame variables for logging runtime environment information
+    cvmfs_repo_name = variable(str, value='None')
+    cvmfs_software_subdir = variable(str, value='None')
+    full_modulepath = variable(str, value='None')
+
+    # Make sure the version of the EESSI test suite gets logged in the ReFrame report
+    eessi_testsuite_version = variable(str, value=testsuite_version)
 
     # Note that the error for an empty parameter is a bit unclear for ReFrame 4.6.2, but that will hopefully improve
     # see https://github.com/reframe-hpc/reframe/issues/3254
@@ -165,3 +174,43 @@ class EESSI_Mixin(RegressionMixin):
     def request_mem(self):
         """Call hook to request the required amount of memory per node"""
         hooks.req_memory_per_node(self, app_mem_req=self.required_mem_per_node())
+
+    @run_after('setup')
+    def log_runtime_info(self):
+        """Log additional runtime information: which CVMFS repo was used (or if it was testing local software),
+        path to the modulefile, EESSI software subdir, EESSI testsuite version"""
+        self.postrun_cmds.append('echo "EESSI_CVMFS_REPO: $EESSI_CVMFS_REPO"')
+        self.postrun_cmds.append('echo "EESSI_SOFTWARE_SUBDIR: $EESSI_SOFTWARE_SUBDIR"')
+        if self.module_name:
+            # Get full modulepath, stripping leading spaces with sed and trailing colon by string substitution
+            get_full_modpath = f'modpath=$(module show {self.module_name} 2>&1 | '
+            get_full_modpath += 'grep ".lua" | '
+            get_full_modpath += 'sed "s/^[[:space:]]*//") && echo "FULL_MODULEPATH: ${modpath%:*}"'
+            self.postrun_cmds.append(get_full_modpath)
+
+    @run_after('run')
+    def extract_runtime_info_from_log(self):
+        """Extracts the printed runtime info from the job log and logs it as reframe variables"""
+        # If EESSI_CVMFS_REPO environment variable was set, extract it and store it in self.cvmfs_repo_name
+        # Try block is needed to surpress sanity error if there is no match
+        try:
+            repo_name = sn.extractsingle(r'EESSI_CVMFS_REPO: /cvmfs/(?P<repo>.*)$', f'{self.stagedir}/{self.stdout}', 'repo', str)
+            if repo_name:
+                self.cvmfs_repo_name = f'{repo_name}'
+        except SanityError:
+             pass
+
+        try:
+            software_subdir = sn.extractsingle(r'EESSI_SOFTWARE_SUBDIR: (?P<subdir>.*)$', f'{self.stagedir}/{self.stdout}', 'subdir', str)
+            if software_subdir:
+                self.cvmfs_software_subdir = f'{software_subdir}'
+        except SanityError:
+            pass
+
+        try:
+            module_path = sn.extractsingle(r'FULL_MODULEPATH: (?P<modpath>.*)$', f'{self.stagedir}/{self.stdout}', 'modpath', str)
+            print(f"Full modulepath: {module_path}")
+            if module_path:
+                self.full_modulepath = f'{module_path}'
+        except SanityError:
+            pass

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -203,8 +203,8 @@ class EESSI_Mixin(RegressionMixin):
             pass
 
         try:
-            software_subdir = sn.extractsingle(r'EESSI_SOFTWARE_SUBDIR: (?P<subdir>.*)$', f'{self.stagedir}/{self.stdout}',
-                                               'subdir', str)
+            software_subdir = sn.extractsingle(r'EESSI_SOFTWARE_SUBDIR: (?P<subdir>.*)$',
+                                               f'{self.stagedir}/{self.stdout}', 'subdir', str)
             if software_subdir:
                 self.cvmfs_software_subdir = f'{software_subdir}'
         except SanityError:

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -200,17 +200,19 @@ class EESSI_Mixin(RegressionMixin):
             if repo_name:
                 self.cvmfs_repo_name = f'{repo_name}'
         except SanityError:
-             pass
+            pass
 
         try:
-            software_subdir = sn.extractsingle(r'EESSI_SOFTWARE_SUBDIR: (?P<subdir>.*)$', f'{self.stagedir}/{self.stdout}', 'subdir', str)
+            software_subdir = sn.extractsingle(r'EESSI_SOFTWARE_SUBDIR: (?P<subdir>.*)$', f'{self.stagedir}/{self.stdout}',
+                                               'subdir', str)
             if software_subdir:
                 self.cvmfs_software_subdir = f'{software_subdir}'
         except SanityError:
             pass
 
         try:
-            module_path = sn.extractsingle(r'FULL_MODULEPATH: (?P<modpath>.*)$', f'{self.stagedir}/{self.stdout}', 'modpath', str)
+            module_path = sn.extractsingle(r'FULL_MODULEPATH: (?P<modpath>.*)$', f'{self.stagedir}/{self.stdout}',
+                                           'modpath', str)
             print(f"Full modulepath: {module_path}")
             if module_path:
                 self.full_modulepath = f'{module_path}'

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -1,5 +1,5 @@
 from reframe.core.builtins import parameter, run_after, variable
-from reframe.core.exceptions import ReframeFatalError, SanityError
+from reframe.core.exceptions import ReframeFatalError
 from reframe.core.pipeline import RegressionMixin
 from reframe.utility.sanity import make_performance_function
 import reframe.utility.sanity as sn
@@ -197,11 +197,11 @@ class EESSI_Mixin(RegressionMixin):
             self.cvmfs_repo_name = f'{repo_name}'
 
         software_subdir = sn.extractall(r'EESSI_SOFTWARE_SUBDIR: (?P<subdir>.*)$',
-                                               f'{self.stagedir}/{self.stdout}', 'subdir', str)
+                                        f'{self.stagedir}/{self.stdout}', 'subdir', str)
         if software_subdir:
             self.cvmfs_software_subdir = f'{software_subdir}'
 
         module_path = sn.extractall(r'FULL_MODULEPATH: (?P<modpath>.*)$', f'{self.stagedir}/{self.stdout}',
-                                           'modpath', str)
+                                    'modpath', str)
         if module_path:
             self.full_modulepath = f'{module_path}'


### PR DESCRIPTION
Solves https://github.com/EESSI/test-suite/issues/196

Note that the nodenames on which the test is run are already logged by the ReFrame framework, so we don't need to do that.

Discussed on the ReFrame slack channel. The challenge is that we want the variables from the batch nodes, so it has to be printed with `postrun_cmds`. But then, we need to get it from the output, and into a ReFrame `variable` so that it is logged. Those need to be initialized in the class body. Then can be updated with the output of the extracted information. We use sanity functions to extract from the output, catching the SanityError that is produced if there is no match (as we don't want the test to _fail_ because of this). Note that SanityError's are actually expected for runs on local software stack, since then the `EESSI_*` environment variables are not set, and the pattern match fails. That's fine, we just want the variables to read `'None'` in those cases.