### PR TITLE
Run local stack of Hortense using `shed_access_in_submit`

### DIFF
--- a/CI/hortense_local_ss/ci_config.sh
+++ b/CI/hortense_local_ss/ci_config.sh
@@ -1,14 +1,16 @@
 # Configurable items
 if [ -z "${TEST_SUITE_PARTITION}" ]; then
+   # do not need this one anymore but it might be needed for GPUS as I suspect it will be neccessary 
+   #for the correct modules to be found
    echo "You have to indicate on which partition the test-suite will run on vsc-Hortense"
    echo "This environment variable needs to be set TEST_SUITE_PARTITION=cpu_rome_256gb"
    echo "Can only set to 'cpu_rome_256gb' untill new functionality of 'sched_options' is part of"
    echo "the ReFrame release https://github.com/reframe-hpc/reframe/issues/2970"
-   exit 1
+   # exit 1
 fi
 
 if [ -z "${REFRAME_ARGS}" ]; then
-    REFRAME_ARGS="--tag CI --tag 1_node|2_nodes --system hortense:${TEST_SUITE_PARTITION}"
+    REFRAME_ARGS="--tag CI --tag 1_node|2_nodes"
 fi
 
 if [ -z "${USE_EESSI_SOFTWARE_STACK}" ]; then
@@ -21,13 +23,13 @@ fi
 
 if [ -z "${UNSET_MODULEPATH}" ]; then
     export UNSET_MODULEPATH=False
-    module --force purge
+    # module --force purge
 fi
 
 if [ -z "${SET_LOCAL_MODULE_ENV}"]; then
-    export SET_LOCAL_MODULE_ENV=True
+    # export SET_LOCAL_MODULE_ENV=True
 fi
 
 if [ -z "${LOCAL_MODULES}"]; then
-    export LOCAL_MODULES="cluster/dodrio/${TEST_SUITE_PARTITION}"
+    # export LOCAL_MODULES="cluster/dodrio/${TEST_SUITE_PARTITION}"
 fi

--- a/CI/hortense_local_ss/ci_config.sh
+++ b/CI/hortense_local_ss/ci_config.sh
@@ -1,12 +1,12 @@
 # Configurable items
-if [ -z "${TEST_SUITE_PARTITION}" ]; then
-   # do not need this one anymore but it might be needed for GPUS as I suspect it will be neccessary 
-   #for the correct modules to be found
-   echo "You have to indicate on which partition the test-suite will run on vsc-Hortense"
-   echo "This environment variable needs to be set TEST_SUITE_PARTITION=cpu_rome_256gb"
-   echo "Can only set to 'cpu_rome_256gb' untill new functionality of 'sched_options' is part of"
-   echo "the ReFrame release https://github.com/reframe-hpc/reframe/issues/2970"
-   # exit 1
+if [[ "$TEST_SUITE_PARTITION" == "GPU" ]]; then
+    module --force purge
+    if [ -z "${SET_LOCAL_MODULE_ENV}"]; then
+        export SET_LOCAL_MODULE_ENV=True
+    fi
+    if [ -z "${LOCAL_MODULES}"]; then
+        export LOCAL_MODULES="cluster/dodrio/gpu_rome_a100"
+    fi
 fi
 
 if [ -z "${REFRAME_ARGS}" ]; then
@@ -23,13 +23,4 @@ fi
 
 if [ -z "${UNSET_MODULEPATH}" ]; then
     export UNSET_MODULEPATH=False
-    # module --force purge
-fi
-
-if [ -z "${SET_LOCAL_MODULE_ENV}"]; then
-    # export SET_LOCAL_MODULE_ENV=True
-fi
-
-if [ -z "${LOCAL_MODULES}"]; then
-    # export LOCAL_MODULES="cluster/dodrio/${TEST_SUITE_PARTITION}"
 fi

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -3,9 +3,10 @@
 #
 # authors: Samuel Moors (VUB-HPC), Kenneth Hoste (HPC-UGent), Lara Peeters (HPC-UGent)
 
+# ReFrame version needs to be 4.7 or older to use the `shed_access_in_submit` option
+
 # Use generated topology file by ReFrame for CPU partitions
-# Cannot use autodetection untill new functionality of `sched_options` is part of
-# the ReFrame release https://github.com/reframe-hpc/reframe/issues/2970
+# `shed_access_in_submit` does not work with setting `'remote_detect': True,`
 
 # Instructions on generating topology file
 # ```
@@ -15,7 +16,7 @@
 #    python3 -m venv "$TMPDIR"/reframe_venv
 #    source "$TMPDIR"/reframe_venv/bin/activate
 #    python3 -m pip install --upgrade pip
-#    python3 -m pip install reframe-hpc=="4.6.2"
+#    python3 -m pip install reframe-hpc=="4.7.2"
 #
 #    mkdir -p ~/.reframe/topology/hortense-{partition_name}
 #    reframe --detect-host-topology \
@@ -64,6 +65,9 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': [prepare_eessi_init, common_eessi_init()],
                     'access': hortense_access + ['--partition=cpu_rome'],
+                    'sched_options': {
+                        'shed_access_in_submit': True,
+                    },
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Rome, 256GiB RAM)',
                     'max_jobs': 20,
@@ -89,6 +93,12 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': [prepare_eessi_init, common_eessi_init()],
                     'access': hortense_access + ['--partition=cpu_rome_512'],
+                    'sched_options': {
+                        'shed_access_in_submit': True,
+                    },
+                    'sched_options': {
+                        'shed_access_in_submit': True,
+                    },
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Rome, 512GiB RAM)',
                     'max_jobs': 20,
@@ -114,6 +124,9 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': [prepare_eessi_init, common_eessi_init()],
                     'access': hortense_access + ['--partition=cpu_milan'],
+                    'sched_options': {
+                        'shed_access_in_submit': True,
+                    },
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Milan, 256GiB RAM)',
                     'max_jobs': 20,
@@ -139,6 +152,9 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': [prepare_eessi_init, common_eessi_init()],
                     'access': hortense_access + ['--partition=gpu_rome_a100_40'],
+                    'sched_options': {
+                        'shed_access_in_submit': True,
+                    },
                     'environs': ['default'],
                     'descr': 'GPU nodes (A100 40GB)',
                     'max_jobs': 20,
@@ -176,6 +192,9 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': [prepare_eessi_init, common_eessi_init()],
                     'access': hortense_access + ['--partition=gpu_rome_a100_80'],
+                    'sched_options': {
+                        'shed_access_in_submit': True,
+                    },
                     'environs': ['default'],
                     'descr': 'GPU nodes (A100 80GB)',
                     'max_jobs': 20,

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -94,9 +94,6 @@ site_configuration = {
                     'sched_options': {
                         'shed_access_in_submit': True,
                     },
-                    'sched_options': {
-                        'shed_access_in_submit': True,
-                    },
                     'environs': ['default'],
                     'descr': 'CPU nodes (AMD Rome, 512GiB RAM)',
                     'max_jobs': 20,

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -3,8 +3,6 @@
 #
 # authors: Samuel Moors (VUB-HPC), Kenneth Hoste (HPC-UGent), Lara Peeters (HPC-UGent)
 
-# ReFrame version needs to be 4.7 or older to use the `shed_access_in_submit` option
-
 # Use generated topology file by ReFrame for CPU partitions
 # `shed_access_in_submit` does not work with setting `'remote_detect': True,`
 
@@ -16,7 +14,7 @@
 #    python3 -m venv "$TMPDIR"/reframe_venv
 #    source "$TMPDIR"/reframe_venv/bin/activate
 #    python3 -m pip install --upgrade pip
-#    python3 -m pip install reframe-hpc=="4.7.2"
+#    python3 -m pip install reframe-hpc=="4.6.2"
 #
 #    mkdir -p ~/.reframe/topology/hortense-{partition_name}
 #    reframe --detect-host-topology \


### PR DESCRIPTION
I thought that `shed_access_in_submit` would only work with ReFrame 4.7 and older but when testing the CI it also seems to work with 4.6.2. Let me know if this is not the case.