### PR TITLE
Bugfix for failing mktemp in CI

### DIFF
--- a/CI/run_reframe.sh
+++ b/CI/run_reframe.sh
@@ -30,7 +30,7 @@ fi
 
 # Create temporary directory
 if [ -z "${TEMPDIR}" ]; then
-    TEMPDIR=$(mktemp --directory --tmpdir=${EESSI_CI_TEMPROOT:-HOME}  -t rfm.XXXXXXXXXX)
+    TEMPDIR=$(mktemp --directory --tmpdir=${EESSI_CI_TEMPROOT:-$HOME}  -t rfm.XXXXXXXXXX)
 fi
 
 # Set the CI configuration for this system


### PR DESCRIPTION
mktemp failed if the CI tempdir env var wasn't defined:
```
$ mktemp --directory --tmpdir=${EESSI_CI_TEMPROOT:-HOME}                                                                           mktemp: failed to create directory via template ‘HOME/tmp.XXXXXXXXXX’: No such file or directory
```
because it would try to substitue HOME (as a string), thus trying to create the directory HOME/tmp.XXXXXXXXXX. We _wanted_ the /ceph/hpc/home/eucasparvl environment variable here