### PR TITLE
simplify executable_opts with new variable user_executable_opts

### DIFF
--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -211,7 +211,6 @@ class EESSI_Mixin(RegressionMixin):
                 'specified on cmd line {[self.user_executable_opts]}')
             self.executable_opts = [self.user_executable_opts]
 
-
     @run_after('run')
     def extract_runtime_info_from_log(self):
         """Extracts the printed runtime info from the job log and logs it as reframe variables"""

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -204,11 +204,13 @@ class EESSI_Mixin(RegressionMixin):
             self.postrun_cmds.append(get_full_modpath)
 
     @run_before('run', always_last=True)
-    def mixin_set_user_executable_opts(self):
+    def EESSI_mixin_set_user_executable_opts(self):
         "Override executable_opts with user_executable_opts if set on the cmd line"
         if self.user_executable_opts:
+            log(f'Overwriting executable_opts {self.executable_opts} by executable_opts '
+                'specified on cmd line {[self.user_executable_opts]}')
             self.executable_opts = [self.user_executable_opts]
-            log(f'executable_opts set to {self.executable_opts}')
+
 
     @run_after('run')
     def extract_runtime_info_from_log(self):

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -41,6 +41,7 @@ class EESSI_Mixin(RegressionMixin):
     # Set defaults for these class variables, can be overwritten by child class if desired
     measure_memory_usage = variable(bool, value=False)
     exact_memory = variable(bool, value=False)
+    user_executable_opts = variable(str, value='')
     scale = parameter(SCALES.keys())
     bench_name = None
     bench_name_ci = None
@@ -201,6 +202,13 @@ class EESSI_Mixin(RegressionMixin):
             # Get full modulepath
             get_full_modpath = f'echo "FULL_MODULEPATH: $(module --location show {self.module_name})"'
             self.postrun_cmds.append(get_full_modpath)
+
+    @run_before('run', always_last=True)
+    def mixin_set_user_executable_opts(self):
+        "Override executable_opts with user_executable_opts if set on the cmd line"
+        if self.user_executable_opts:
+            self.executable_opts = [self.user_executable_opts]
+            log(f'executable_opts set to {self.executable_opts}')
 
     @run_after('run')
     def extract_runtime_info_from_log(self):

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -619,18 +619,6 @@ def set_tag_scale(test: rfm.RegressionTest):
     log(f'tags set to {test.tags}')
 
 
-def check_custom_executable_opts(test: rfm.RegressionTest, num_default: int = 0):
-    """"
-    Check if custom executable options were added with --setvar executable_opts=<x>.
-    """
-    # normalize options
-    test.executable_opts = shlex.split(' '.join(test.executable_opts))
-    test.has_custom_executable_opts = False
-    if len(test.executable_opts) > num_default:
-        test.has_custom_executable_opts = True
-    log(f'has_custom_executable_opts set to {test.has_custom_executable_opts}')
-
-
 def set_compact_process_binding(test: rfm.RegressionTest):
     """
     This hook sets a binding policy for process binding.

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -2,7 +2,6 @@
 Hooks for adding tags, filtering and setting job resources in ReFrame tests
 """
 import math
-import shlex
 
 import reframe as rfm
 import reframe.core.logging as rflog

--- a/eessi/testsuite/tests/apps/espresso/espresso.py
+++ b/eessi/testsuite/tests/apps/espresso/espresso.py
@@ -127,8 +127,6 @@ class EESSI_ESPRESSO_P3M_IONIC_CRYSTALS(EESSI_ESPRESSO):
     @run_after('init')
     def set_executable_opts(self):
         """Set executable opts based on device_type parameter"""
-        num_default = 0  # If this test already has executable opts, they must have come from the command line
-        hooks.check_custom_executable_opts(self, num_default=num_default)
         # By default we run weak scaling since the strong scaling sizes need to change based on max node size and a
         # corresponding min node size has to be chozen.
         self.executable_opts += ['--size', str(self.default_weak_scaling_system_size), '--weak-scaling']
@@ -174,12 +172,6 @@ class EESSI_ESPRESSO_LJ_PARTICLES(EESSI_ESPRESSO):
             log(f'tags set to {self.tags}')
 
         self.tags.add('particles_lj')
-
-    @run_after('init')
-    def set_executable_opts(self):
-        """Allow executable opts to be overwritten from command line"""
-        num_default = 0  # If this test already has executable opts, they must have come from the command line
-        hooks.check_custom_executable_opts(self, num_default=num_default)
 
     @run_after('setup')
     def set_mem(self):

--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -34,7 +34,6 @@ from reframe.core.builtins import parameter, run_after  # added only to make the
 
 from hpctestlib.sciapps.gromacs.benchmarks import gromacs_check
 
-from eessi.testsuite import hooks
 from eessi.testsuite.constants import COMPUTE_UNIT, DEVICE_TYPES, SCALES
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 from eessi.testsuite.utils import find_modules, log
@@ -54,6 +53,8 @@ class EESSI_GROMACS(EESSI_GROMACS_base, EESSI_Mixin):
     bench_name_ci = 'HECBioSim/Crambin'
     # input files are downloaded
     readonly_files = ['']
+    # executable_opts in addition to those set by the hpctestlib
+    executable_opts = ['-dlb', 'yes', '-npme', '-1']
 
     def required_mem_per_node(self):
         return self.num_tasks_per_node * 1024
@@ -75,19 +76,6 @@ class EESSI_GROMACS(EESSI_GROMACS_base, EESSI_Mixin):
         else:
             msg = f"No mapping of device type {self.device_type} to a COMPUTE_UNIT was specified in this test"
             raise NotImplementedError(msg)
-
-    @run_after('setup')
-    def set_executable_opts(self):
-        """
-        Add extra executable_opts, unless specified via --setvar executable_opts=<x>
-        Set default executable_opts and support setting custom executable_opts on the cmd line.
-        """
-
-        num_default = 4  # normalized number of executable opts added by parent class (gromacs_check)
-        hooks.check_custom_executable_opts(self, num_default=num_default)
-        if not self.has_custom_executable_opts:
-            self.executable_opts += ['-dlb', 'yes', '-npme', '-1']
-            log(f'executable_opts set to {self.executable_opts}')
 
     @run_after('setup')
     def set_omp_num_threads(self):

--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -85,13 +85,9 @@ class EESSI_GROMACS(EESSI_GROMACS_base, EESSI_Mixin):
         Set default number of OpenMP threads equal to number of CPUs per task.
         Also support setting OpenMP threads on the cmd line via custom executable option '-ntomp'.
         """
-
-        if '-ntomp' in self.executable_opts:
-            omp_num_threads = self.executable_opts[self.executable_opts.index('-ntomp') + 1]
-        else:
-            omp_num_threads = self.num_cpus_per_task
-            self.executable_opts += ['-ntomp', str(omp_num_threads)]
-            log(f'executable_opts set to {self.executable_opts}')
+        omp_num_threads = self.num_cpus_per_task
+        self.executable_opts += ['-ntomp', str(omp_num_threads)]
+        log(f'executable_opts set to {self.executable_opts}')
 
         self.env_vars['OMP_NUM_THREADS'] = omp_num_threads
         log(f'env_vars set to {self.env_vars}')

--- a/eessi/testsuite/tests/apps/lammps/lammps.py
+++ b/eessi/testsuite/tests/apps/lammps/lammps.py
@@ -103,24 +103,19 @@ class EESSI_LAMMPS_lj(EESSI_LAMMPS_base, EESSI_Mixin):
     @run_after('setup')
     def set_executable_opts(self):
         """Set executable opts based on device_type parameter"""
-        num_default = 0  # If this test already has executable opts, they must have come from the command line
-        hooks.check_custom_executable_opts(self, num_default=num_default)
-        if not self.has_custom_executable_opts:
-            # should also check if the lammps is installed with kokkos.
-            # Because this exutable opt is only for that case.
-            if self.device_type == "gpu":
-                if 'kokkos' in self.module_name:
-                    self.executable_opts += [
-                        f'-kokkos on t {self.num_cpus_per_task} g {self.num_gpus_per_node}',
-                        '-suffix kk',
-                        '-package kokkos newton on neigh half',
-                    ]
-                    utils.log(f'executable_opts set to {self.executable_opts}')
-                else:
-                    self.executable_opts += [
-                        f'-suffix gpu -package gpu {self.num_gpus_per_node}',
-                    ]
-                    utils.log(f'executable_opts set to {self.executable_opts}')
+        # should also check if the lammps is installed with kokkos.
+        # Because this executable opt is only for that case.
+        if self.device_type == "gpu":
+            if 'kokkos' in self.module_name:
+                self.executable_opts += [
+                    f'-kokkos on t {self.num_cpus_per_task} g {self.num_gpus_per_node}',
+                    '-suffix kk',
+                    '-package kokkos newton on neigh half',
+                ]
+                utils.log(f'executable_opts set to {self.executable_opts}')
+            else:
+                self.executable_opts += [f'-suffix gpu -package gpu {self.num_gpus_per_node}']
+                utils.log(f'executable_opts set to {self.executable_opts}')
 
 
 @rfm.simple_test
@@ -163,21 +158,16 @@ class EESSI_LAMMPS_rhodo(EESSI_LAMMPS_base, EESSI_Mixin):
     @run_after('setup')
     def set_executable_opts(self):
         """Set executable opts based on device_type parameter"""
-        num_default = 0  # If this test already has executable opts, they must have come from the command line
-        hooks.check_custom_executable_opts(self, num_default=num_default)
-        if not self.has_custom_executable_opts:
-            # should also check if the lammps is installed with kokkos.
-            # Because this exutable opt is only for that case.
-            if self.device_type == "gpu":
-                if 'kokkos' in self.module_name:
-                    self.executable_opts += [
-                        f'-kokkos on t {self.num_cpus_per_task} g {self.num_gpus_per_node}',
-                        '-suffix kk',
-                        '-package kokkos newton on neigh half',
-                    ]
-                    utils.log(f'executable_opts set to {self.executable_opts}')
-                else:
-                    self.executable_opts += [
-                        f'-suffix gpu -package gpu {self.num_gpus_per_node}',
-                    ]
-                    utils.log(f'executable_opts set to {self.executable_opts}')
+        # should also check if the lammps is installed with kokkos.
+        # Because this executable opt is only for that case.
+        if self.device_type == "gpu":
+            if 'kokkos' in self.module_name:
+                self.executable_opts += [
+                    f'-kokkos on t {self.num_cpus_per_task} g {self.num_gpus_per_node}',
+                    '-suffix kk',
+                    '-package kokkos newton on neigh half',
+                ]
+                utils.log(f'executable_opts set to {self.executable_opts}')
+            else:
+                self.executable_opts += [f'-suffix gpu -package gpu {self.num_gpus_per_node}']
+                utils.log(f'executable_opts set to {self.executable_opts}')

--- a/eessi/testsuite/tests/apps/lammps/lammps.py
+++ b/eessi/testsuite/tests/apps/lammps/lammps.py
@@ -6,7 +6,7 @@ The tests come from the lammps github repository (https://github.com/lammps/lamm
 import reframe as rfm
 import reframe.utility.sanity as sn
 
-from eessi.testsuite import hooks, utils
+from eessi.testsuite import utils
 from eessi.testsuite.constants import *  # noqa
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 

--- a/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
+++ b/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
@@ -72,11 +72,8 @@ class EESSI_TensorFlow(rfm.RunOnlyRegressionTest, EESSI_Mixin):
     @run_after('init')
     def set_executable_opts(self):
         """Set executable opts based on device_type parameter"""
-        num_default = 0  # If this test already has executable opts, they must have come from the command line
-        hooks.check_custom_executable_opts(self, num_default=num_default)
-        if not self.has_custom_executable_opts:
-            self.executable_opts += ['--device', self.device_type]
-            utils.log(f'executable_opts set to {self.executable_opts}')
+        self.executable_opts += ['--device', self.device_type]
+        utils.log(f'executable_opts set to {self.executable_opts}')
 
     @run_after('init')
     def set_test_descr(self):
@@ -97,7 +94,6 @@ class EESSI_TensorFlow(rfm.RunOnlyRegressionTest, EESSI_Mixin):
     @run_after('setup')
     def set_thread_count_args(self):
         """Set executable opts defining the thread count"""
-        if not self.has_custom_executable_opts:
-            self.executable_opts += ['--intra-op-parallelism', '%s' % self.num_cpus_per_task]
-            self.executable_opts += ['--inter-op-parallelism', '1']
-            utils.log(f'executable_opts set to {self.executable_opts}')
+        self.executable_opts += ['--intra-op-parallelism', '%s' % self.num_cpus_per_task]
+        self.executable_opts += ['--inter-op-parallelism', '1']
+        utils.log(f'executable_opts set to {self.executable_opts}')

--- a/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
+++ b/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
@@ -8,7 +8,7 @@ import reframe as rfm
 from reframe.core.builtins import deferrable, parameter, run_after, sanity_function, performance_function
 import reframe.utility.sanity as sn
 
-from eessi.testsuite import hooks, utils
+from eessi.testsuite import utils
 from eessi.testsuite.constants import COMPUTE_UNIT, CPU, CPU_SOCKET, DEVICE_TYPES, GPU
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 


### PR DESCRIPTION
this PR adds a new `variable` `user_executable_opts` to the `EESSI_Mixin` class, which users can specify on the cmd line. advantages:
- gives users full control of the executable options: it will *completely* override the ones set in the test
- simplifies the tests: no more annoying `check_custom_executable_opts(self, num_default=num_default)` and `has_custom_executable_opts`
- consistency: some tests were using `check_custom_executable_opts` and `has_custom_executable_opts`, others were not.