### PR TITLE
use namedtuples for constants

### DIFF
--- a/config/aws_citc.py
+++ b/config/aws_citc.py
@@ -221,7 +221,7 @@ partition_defaults = {
     'launcher': 'mpirun',
     'environs': ['default'],
     'features': [
-        FEATURES['CPU']
+        FEATURES.CPU
     ],
     'prepare_cmds': [
         common_eessi_init(),

--- a/config/aws_mc.py
+++ b/config/aws_mc.py
@@ -13,7 +13,7 @@
 import os
 
 from eessi.testsuite.common_config import common_logging_config, common_general_config, common_eessi_init
-from eessi.testsuite.constants import FEATURES, SCALES
+from eessi.testsuite.constants import EXTRAS, FEATURES, SCALES
 
 # This config will write all staging, output and logging to subdirs under this prefix
 # Override with RFM_PREFIX environment variable
@@ -97,7 +97,7 @@ partition_defaults = {
     'launcher': 'mpirun',
     'environs': ['default'],
     'features': [
-        FEATURES['CPU']
+        FEATURES.CPU
     ] + list(SCALES.keys()),
     'prepare_cmds': [
         common_eessi_init(),
@@ -114,7 +114,7 @@ partition_defaults = {
     'extras': {
         # Node types have somewhat varying amounts of memory, but we'll make it easy on ourselves
         # All should _at least_ have this amount (30GB * 1E9 / (1024*1024) = 28610 MiB)
-        'mem_per_node': 28610
+        EXTRAS.MEM_PER_NODE: 28610
     },
     'max_jobs': 1,
 }

--- a/config/azure_mc.py
+++ b/config/azure_mc.py
@@ -13,7 +13,7 @@
 import os
 
 from eessi.testsuite.common_config import common_logging_config, common_general_config, common_eessi_init
-from eessi.testsuite.constants import FEATURES, SCALES
+from eessi.testsuite.constants import EXTRAS, FEATURES, SCALES
 
 # This config will write all staging, output and logging to subdirs under this prefix
 # Override with RFM_PREFIX environment variable
@@ -50,7 +50,7 @@ site_configuration = {
                     'extras': {
                         # For some reason, we cannot ask for the full amount configured as RealMemory in
                         # /etc/slurm/nodes.conf, so we ask slightly less
-                        'mem_per_node': 767480
+                        EXTRAS.MEM_PER_NODE: 767480
                     },
                 },
                 {
@@ -67,7 +67,7 @@ site_configuration = {
                     'extras': {
                         # For some reason, we cannot ask for the full amount configured as RealMemory in
                         # /etc/slurm/nodes.conf, so we ask slightly less
-                        'mem_per_node': 63480
+                        EXTRAS.MEM_PER_NODE: 63480
                     },
                 },
             ]
@@ -98,7 +98,7 @@ partition_defaults = {
     'launcher': 'mpirun',
     'environs': ['default'],
     'features': [
-        FEATURES['CPU']
+        FEATURES.CPU
     ] + list(SCALES.keys()),
     'resources': [
         {

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -17,7 +17,7 @@ site_configuration = {
                     'scheduler': 'local',
                     'launcher': 'local',
                     'environs': ['default'],
-                    'features': [FEATURES[CPU]] + list(SCALES.keys()),
+                    'features': [FEATURES.CPU] + list(SCALES.keys()),
                     'processor': {
                         'num_cpus': 2,
                         'num_cpus_per_core': 1,
@@ -33,7 +33,7 @@ site_configuration = {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
                         # This is a fictional amount, GH actions probably has less, but only does --dry-run
-                        'mem_per_node': 30 * 1024  # in MiB
+                        EXTRAS.MEM_PER_NODE: 30 * 1024  # in MiB
                     },
                 }
             ]

--- a/config/it4i_karolina.py
+++ b/config/it4i_karolina.py
@@ -58,7 +58,7 @@ site_configuration = {
                     'environs': ['default'],
                     'max_jobs': 120,
                     'features': [
-                        FEATURES[CPU],
+                        FEATURES.CPU,
                     ] + list(SCALES.keys()),
                     'resources': [
                         {
@@ -69,7 +69,7 @@ site_configuration = {
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 235520  # in MiB
+                        EXTRAS.MEM_PER_NODE: 235520  # in MiB
                     },
                     'descr': 'CPU Universal Compute Nodes, see https://docs.it4i.cz/karolina/hardware-overview/'
                 },
@@ -95,7 +95,7 @@ site_configuration = {
                 #     'max_jobs': 60,
                 #     'devices': [
                 #         {
-                #             'type': DEVICE_TYPES[GPU],
+                #             'type': DEVICE_TYPES.GPU,
                 #             'num_devices': 8,
                 #         }
                 #     ],
@@ -106,7 +106,7 @@ site_configuration = {
                 #         }
                 #     ],
                 #     'features': [
-                #         FEATURES[GPU],
+                #         FEATURES.GPU,
                 #     ] + list(SCALES.keys()),
                 #     'descr': 'GPU partition with accelerated nodes, https://docs.it4i.cz/karolina/hardware-overview/'
                 # },

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -57,14 +57,14 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[CPU],
+                        FEATURES.CPU,
                     ] + list(SCALES.keys()),
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
                         # NB: Vega's MaxMemPerNode is set to 256000, but this MUST be a MB/MiB units mistake
                         # Most likely, it is 256 GB, so 256*1E9/(1024*1024) MiB
-                        'mem_per_node': 244140  # in MiB
+                        EXTRAS.MEM_PER_NODE: 244140  # in MiB
                     },
                     'descr': 'CPU partition Standard, see https://en-doc.vega.izum.si/architecture/'
                 },
@@ -88,7 +88,7 @@ site_configuration = {
                     'max_jobs': 60,
                     'devices': [
                         {
-                            'type': DEVICE_TYPES[GPU],
+                            'type': DEVICE_TYPES.GPU,
                             'num_devices': 4,
                         }
                     ],
@@ -103,13 +103,13 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[GPU],
+                        FEATURES.GPU,
                     ] + list(SCALES.keys()),
                     'extras': {
-                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
+                        EXTRAS.GPU_VENDOR: GPU_VENDORS.NVIDIA,
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 476.837 * 1024  # in MiB (should be checked, its unclear from slurm.conf)
+                        EXTRAS.MEM_PER_NODE: 476.837 * 1024  # in MiB (should be checked, its unclear from slurm.conf)
                     },
                     'descr': 'GPU partition, see https://en-doc.vega.izum.si/architecture/'
                 },

--- a/config/macc_deucalion.py
+++ b/config/macc_deucalion.py
@@ -41,14 +41,14 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[CPU],
+                        FEATURES.CPU,
                     ] + list(SCALES.keys()),
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
                         # NB: Deucalion's MaxMemPerNode is undefined. Experimentally I found you cannot submit with
                         # more than --mem=30000M
-                        'mem_per_node': 30000  # in MiB
+                        EXTRAS.MEM_PER_NODE: 30000  # in MiB
                     },
                     'descr': 'CPU ARM A64FX partition, see https://docs.macc.fccn.pt/deucalion/#compute-nodes'
                 },

--- a/config/settings_example.py
+++ b/config/settings_example.py
@@ -20,7 +20,7 @@ Example configuration file
 import os
 
 from eessi.testsuite.common_config import common_logging_config, common_general_config, common_eessi_init
-from eessi.testsuite.constants import FEATURES, CPU, GPU, SCALES, DEVICE_TYPES, GPU_VENDOR, GPU_VENDORS, NVIDIA
+from eessi.testsuite.constants import EXTRAS, FEATURES, SCALES, DEVICE_TYPES, GPU_VENDORS
 
 
 site_configuration = {
@@ -61,11 +61,11 @@ site_configuration = {
                         # on nodes in this partition
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 229376  # in MiB
+                        EXTRAS.MEM_PER_NODE: 229376  # in MiB
                     },
                     # list(SCALES.keys()) adds all the scales from eessi.testsuite.constants as valid for thi partition
                     # Can be modified if not all scales can run on this partition, see e.g. the surf_snellius.py config
-                    'features': [FEATURES[CPU]] + list(SCALES.keys()),
+                    'features': [FEATURES.CPU] + list(SCALES.keys()),
                 },
                 {
                     'name': 'gpu_partition',
@@ -96,21 +96,21 @@ site_configuration = {
                     ],
                     'devices': [
                         {
-                            'type': DEVICE_TYPES[GPU],
+                            'type': DEVICE_TYPES.GPU,
                             'num_devices': 4,
                         }
                     ],
                     'features': [
-                        FEATURES[CPU],
-                        FEATURES[GPU],
+                        FEATURES.CPU,
+                        FEATURES.GPU,
                     ] + list(SCALES.keys()),
                     'extras': {
                         # If you have slurm, check with scontrol show node <nodename> for the amount of RealMemory
                         # on nodes in this partition
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 229376,  # in MiB
-                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
+                        EXTRAS.MEM_PER_NODE: 229376,  # in MiB
+                        EXTRAS.GPU_VENDOR: GPU_VENDORS.NVIDIA,
                     },
                 },
             ]

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -53,12 +53,12 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[CPU],
+                        FEATURES.CPU,
                     ] + list(SCALES.keys()),
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 229376  # in MiB
+                        EXTRAS.MEM_PER_NODE: 229376  # in MiB
                     },
                     'descr': 'AMD Rome CPU partition with native EESSI stack'
                 },
@@ -82,12 +82,12 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[CPU],
+                        FEATURES.CPU,
                     ] + list(SCALES.keys()),
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 344064  # in MiB
+                        EXTRAS.MEM_PER_NODE: 344064  # in MiB
                     },
                     'descr': 'AMD Genoa CPU partition with native EESSI stack'
                 },
@@ -101,7 +101,7 @@ site_configuration = {
                     'max_jobs': 60,
                     'devices': [
                         {
-                            'type': DEVICE_TYPES[GPU],
+                            'type': DEVICE_TYPES.GPU,
                             'num_devices': 4,
                         }
                     ],
@@ -116,14 +116,14 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[GPU],
-                        FEATURES[ALWAYS_REQUEST_GPUS],
+                        FEATURES.GPU,
+                        FEATURES.ALWAYS_REQUEST_GPUS,
                     ] + valid_scales_snellius_gpu,
                     'extras': {
-                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
+                        EXTRAS.GPU_VENDOR: GPU_VENDORS.NVIDIA,
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 491520  # in MiB
+                        EXTRAS.MEM_PER_NODE: 491520  # in MiB
                     },
                     'descr': 'Nvidia A100 GPU partition with native EESSI stack'
                 },
@@ -137,7 +137,7 @@ site_configuration = {
                     'max_jobs': 60,
                     'devices': [
                         {
-                            'type': DEVICE_TYPES[GPU],
+                            'type': DEVICE_TYPES.GPU,
                             'num_devices': 4,
                         }
                     ],
@@ -152,14 +152,14 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[GPU],
-                        FEATURES[ALWAYS_REQUEST_GPUS],
+                        FEATURES.GPU,
+                        FEATURES.ALWAYS_REQUEST_GPUS,
                     ] + valid_scales_snellius_gpu,
                     'extras': {
-                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
+                        EXTRAS.GPU_VENDOR: GPU_VENDORS.NVIDIA,
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 737280  # in MiB
+                        EXTRAS.MEM_PER_NODE: 737280  # in MiB
                     },
                     'descr': 'Nvidia H100 GPU partition with native EESSI stack'
                 },

--- a/config/vsc_hortense.py
+++ b/config/vsc_hortense.py
@@ -78,12 +78,12 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[CPU],
+                        FEATURES.CPU,
                     ] + list(SCALES.keys()),
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 252160,  # in MiB
+                        EXTRAS.MEM_PER_NODE: 252160,  # in MiB
                     },
                 },
                 {
@@ -106,12 +106,12 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[CPU],
+                        FEATURES.CPU,
                     ] + list(SCALES.keys()),
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 508160,  # in MiB
+                        EXTRAS.MEM_PER_NODE: 508160,  # in MiB
                     },
                 },
                 {
@@ -134,12 +134,12 @@ site_configuration = {
                         }
                     ],
                     'features': [
-                        FEATURES[CPU],
+                        FEATURES.CPU,
                     ] + list(SCALES.keys()),
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 252160,  # in MiB
+                        EXTRAS.MEM_PER_NODE: 252160,  # in MiB
                     },
                 },
                 {
@@ -156,13 +156,13 @@ site_configuration = {
                     'launcher': launcher,
                     'modules': [mpi_module.format('gpu_rome_a100_40')],
                     'features': [
-                        FEATURES[GPU],
+                        FEATURES.GPU,
                     ] + list(SCALES.keys()),
                     'extras': {
-                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
+                        EXTRAS.GPU_VENDOR: GPU_VENDORS.NVIDIA,
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 254400,  # in MiB
+                        EXTRAS.MEM_PER_NODE: 254400,  # in MiB
                     },
                     'resources': [
                         {
@@ -176,7 +176,7 @@ site_configuration = {
                     ],
                     'devices': [
                         {
-                            'type': DEVICE_TYPES[GPU],
+                            'type': DEVICE_TYPES.GPU,
                             'num_devices': 4,
                         }
                     ],
@@ -196,13 +196,13 @@ site_configuration = {
                     'launcher': launcher,
                     'modules': [mpi_module.format('gpu_rome_a100_80')],
                     'features': [
-                        FEATURES[GPU],
+                        FEATURES.GPU,
                     ] + list(SCALES.keys()),
                     'extras': {
-                        GPU_VENDOR: GPU_VENDORS[NVIDIA],
+                        EXTRAS.GPU_VENDOR: GPU_VENDORS.NVIDIA,
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node
-                        'mem_per_node': 510720,  # in MiB
+                        EXTRAS.MEM_PER_NODE: 510720,  # in MiB
                     },
                     'resources': [
                         {
@@ -216,7 +216,7 @@ site_configuration = {
                     ],
                     'devices': [
                         {
-                            'type': DEVICE_TYPES[GPU],
+                            'type': DEVICE_TYPES.GPU,
                             'num_devices': 4,
                         }
                     ],

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -1,49 +1,55 @@
 """
 Constants for ReFrame tests
 """
+from typing import NamedTuple
 
-AMD = 'AMD'
-CI = 'CI'
-HWTHREAD = 'HWTHREAD'
-CPU = 'CPU'
-CPU_SOCKET = 'CPU_SOCKET'
-NUMA_NODE = 'NUMA_NODE'
-GPU = 'GPU'
-GPU_VENDOR = 'GPU_VENDOR'
-INTEL = 'INTEL'
-NODE = 'NODE'
-NVIDIA = 'NVIDIA'
-ALWAYS_REQUEST_GPUS = 'ALWAYS_REQUEST_GPUS'
 
-DEVICE_TYPES = {
-    CPU: 'cpu',
-    GPU: 'gpu',
-}
+class Extras(NamedTuple):
+    GPU_VENDOR = 'gpu_vendor'
+    MEM_PER_NODE = 'mem_per_node'
 
-COMPUTE_UNIT = {
-    HWTHREAD: 'hwthread',
-    CPU: 'cpu',
-    CPU_SOCKET: 'cpu_socket',
-    NUMA_NODE: 'numa_node',
-    GPU: 'gpu',
-    NODE: 'node',
-}
 
-TAGS = {
-    CI: 'CI',
-}
+class DeviceTypes(NamedTuple):
+    "device types"
+    CPU = 'cpu'
+    GPU = 'gpu'
 
-FEATURES = {
-    CPU: 'cpu',
-    GPU: 'gpu',
-    ALWAYS_REQUEST_GPUS: 'always_request_gpus',
-}
 
-GPU_VENDORS = {
-    AMD: 'amd',
-    INTEL: 'intel',
-    NVIDIA: 'nvidia',
-}
+class ComputeUnits(NamedTuple):
+    "compute units"
+    CPU = 'cpu'
+    CPU_SOCKET = 'cpu_socket'
+    GPU = 'gpu'
+    HWTHREAD = 'hwthread'
+    NODE = 'node'
+    NUMA_NODE = 'numa_node'
+
+
+class Tags(NamedTuple):
+    "tags"
+    CI = 'CI'
+
+
+class Features(NamedTuple):
+    "features"
+    CPU = 'cpu'
+    GPU = 'gpu'
+    ALWAYS_REQUEST_GPUS = 'always_request_gpus'
+
+
+class GPUVendors(NamedTuple):
+    "GPU vendors"
+    AMD = 'amd'
+    INTEL = 'intel'
+    NVIDIA = 'nvidia'
+
+
+EXTRAS = Extras()
+DEVICE_TYPES = DeviceTypes()
+COMPUTE_UNITS = ComputeUnits()
+TAGS = Tags()
+FEATURES = Features()
+GPU_VENDORS = GPUVendors()
 
 SCALES = {
     # required keys:

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -5,6 +5,7 @@ from typing import NamedTuple
 
 
 class Extras(NamedTuple):
+    "extras keys"
     GPU_VENDOR: str = 'gpu_vendor'
     MEM_PER_NODE: str = 'mem_per_node'
 

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -5,43 +5,43 @@ from typing import NamedTuple
 
 
 class Extras(NamedTuple):
-    GPU_VENDOR = 'gpu_vendor'
-    MEM_PER_NODE = 'mem_per_node'
+    GPU_VENDOR: str = 'gpu_vendor'
+    MEM_PER_NODE: str = 'mem_per_node'
 
 
 class DeviceTypes(NamedTuple):
     "device types"
-    CPU = 'cpu'
-    GPU = 'gpu'
+    CPU: str = 'cpu'
+    GPU: str = 'gpu'
 
 
 class ComputeUnits(NamedTuple):
     "compute units"
-    CPU = 'cpu'
-    CPU_SOCKET = 'cpu_socket'
-    GPU = 'gpu'
-    HWTHREAD = 'hwthread'
-    NODE = 'node'
-    NUMA_NODE = 'numa_node'
+    CPU: str = 'cpu'
+    CPU_SOCKET: str = 'cpu_socket'
+    GPU: str = 'gpu'
+    HWTHREAD: str = 'hwthread'
+    NODE: str = 'node'
+    NUMA_NODE: str = 'numa_node'
 
 
 class Tags(NamedTuple):
     "tags"
-    CI = 'CI'
+    CI: str = 'CI'
 
 
 class Features(NamedTuple):
     "features"
-    CPU = 'cpu'
-    GPU = 'gpu'
-    ALWAYS_REQUEST_GPUS = 'always_request_gpus'
+    CPU: str = 'cpu'
+    GPU: str = 'gpu'
+    ALWAYS_REQUEST_GPUS: str = 'always_request_gpus'
 
 
 class GPUVendors(NamedTuple):
     "GPU vendors"
-    AMD = 'amd'
-    INTEL = 'intel'
-    NVIDIA = 'nvidia'
+    AMD: str = 'amd'
+    INTEL: str = 'intel'
+    NVIDIA: str = 'nvidia'
 
 
 EXTRAS = Extras()

--- a/eessi/testsuite/constants.py
+++ b/eessi/testsuite/constants.py
@@ -4,19 +4,19 @@ Constants for ReFrame tests
 from typing import NamedTuple
 
 
-class Extras(NamedTuple):
+class _Extras(NamedTuple):
     "extras keys"
     GPU_VENDOR: str = 'gpu_vendor'
     MEM_PER_NODE: str = 'mem_per_node'
 
 
-class DeviceTypes(NamedTuple):
+class _DeviceTypes(NamedTuple):
     "device types"
     CPU: str = 'cpu'
     GPU: str = 'gpu'
 
 
-class ComputeUnits(NamedTuple):
+class _ComputeUnits(NamedTuple):
     "compute units"
     CPU: str = 'cpu'
     CPU_SOCKET: str = 'cpu_socket'
@@ -26,31 +26,31 @@ class ComputeUnits(NamedTuple):
     NUMA_NODE: str = 'numa_node'
 
 
-class Tags(NamedTuple):
+class _Tags(NamedTuple):
     "tags"
     CI: str = 'CI'
 
 
-class Features(NamedTuple):
+class _Features(NamedTuple):
     "features"
     CPU: str = 'cpu'
     GPU: str = 'gpu'
     ALWAYS_REQUEST_GPUS: str = 'always_request_gpus'
 
 
-class GPUVendors(NamedTuple):
+class _GPUVendors(NamedTuple):
     "GPU vendors"
     AMD: str = 'amd'
     INTEL: str = 'intel'
     NVIDIA: str = 'nvidia'
 
 
-EXTRAS = Extras()
-DEVICE_TYPES = DeviceTypes()
-COMPUTE_UNITS = ComputeUnits()
-TAGS = Tags()
-FEATURES = Features()
-GPU_VENDORS = GPUVendors()
+EXTRAS = _Extras()
+DEVICE_TYPES = _DeviceTypes()
+COMPUTE_UNITS = _ComputeUnits()
+TAGS = _Tags()
+FEATURES = _Features()
+GPU_VENDORS = _GPUVendors()
 
 SCALES = {
     # required keys:

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -5,7 +5,7 @@ from reframe.utility.sanity import make_performance_function
 import reframe.utility.sanity as sn
 
 from eessi.testsuite import hooks
-from eessi.testsuite.constants import CI, DEVICE_TYPES, SCALES, COMPUTE_UNIT, TAGS
+from eessi.testsuite.constants import DEVICE_TYPES, SCALES, COMPUTE_UNITS, TAGS
 from eessi.testsuite.utils import log
 from eessi.testsuite import __version__ as testsuite_version
 
@@ -153,7 +153,7 @@ class EESSI_Mixin(RegressionMixin):
                 msg = "Attribute bench_name_ci is set, but bench_name is not set"
                 raise ReframeFatalError(msg)
             if self.bench_name == self.bench_name_ci:
-                self.tags.add(TAGS[CI])
+                self.tags.add(TAGS.CI)
                 tags_added = True
         if self.bench_name:
             self.tags.add(self.bench_name)
@@ -182,7 +182,7 @@ class EESSI_Mixin(RegressionMixin):
 
         # Check that the value for these variables is valid
         # i.e. exists in their respective dict from eessi.testsuite.constants
-        self.EESSI_mixin_validate_item_in_dict('compute_unit', COMPUTE_UNIT)
+        self.EESSI_mixin_validate_item_in_dict('compute_unit', COMPUTE_UNITS)
 
     @run_after('setup')
     def EESSI_mixin_assign_tasks_per_compute_unit(self):

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -82,16 +82,12 @@ class EESSI_Mixin(RegressionMixin):
 
     # Helper function to validate if an attribute is present it item_dict.
     # If not, print it's current name, value, and the valid_values
-    def EESSI_mixin_validate_item_in_dict(self, item, item_dict, check_keys=False):
+    def EESSI_mixin_validate_item_in_list(self, item, valid_items):
         """
         Check if the item 'item' exist in the values of 'item_dict'.
-        If check_keys=True, then it will check instead of 'item' exists in the keys of 'item_dict'.
+        If check_keys=True, then it will check instead if 'item' exists in the keys of 'item_dict'.
         If item is not found, an error will be raised that will mention the valid values for 'item'.
         """
-        if check_keys:
-            valid_items = list(item_dict.keys())
-        else:
-            valid_items = list(item_dict.values())
 
         value = getattr(self, item)
         if value not in valid_items:
@@ -114,10 +110,10 @@ class EESSI_Mixin(RegressionMixin):
 
         # Check that the value for these variables is valid,
         # i.e. exists in their respective dict from eessi.testsuite.constants
-        self.EESSI_mixin_validate_item_in_dict('device_type', DEVICE_TYPES)
-        self.EESSI_mixin_validate_item_in_dict('scale', SCALES, check_keys=True)
-        self.EESSI_mixin_validate_item_in_dict('valid_systems', {'valid_systems': ['*']})
-        self.EESSI_mixin_validate_item_in_dict('valid_prog_environs', {'valid_prog_environs': ['default']})
+        self.EESSI_mixin_validate_item_in_list('device_type', DEVICE_TYPES[:])
+        self.EESSI_mixin_validate_item_in_list('scale', SCALES.keys())
+        self.EESSI_mixin_validate_item_in_list('valid_systems', [['*']])
+        self.EESSI_mixin_validate_item_in_list('valid_prog_environs', [['default']])
 
     @run_after('init')
     def EESSI_mixin_run_after_init(self):
@@ -182,7 +178,7 @@ class EESSI_Mixin(RegressionMixin):
 
         # Check that the value for these variables is valid
         # i.e. exists in their respective dict from eessi.testsuite.constants
-        self.EESSI_mixin_validate_item_in_dict('compute_unit', COMPUTE_UNITS)
+        self.EESSI_mixin_validate_item_in_list('compute_unit', COMPUTE_UNITS[:])
 
     @run_after('setup')
     def EESSI_mixin_assign_tasks_per_compute_unit(self):

--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -84,11 +84,9 @@ class EESSI_Mixin(RegressionMixin):
     # If not, print it's current name, value, and the valid_values
     def EESSI_mixin_validate_item_in_list(self, item, valid_items):
         """
-        Check if the item 'item' exist in the values of 'item_dict'.
-        If check_keys=True, then it will check instead if 'item' exists in the keys of 'item_dict'.
+        Check if the item 'item' exist in the values of 'valid_items'.
         If item is not found, an error will be raised that will mention the valid values for 'item'.
         """
-
         value = getattr(self, item)
         if value not in valid_items:
             if len(valid_items) == 1:

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -7,9 +7,8 @@ import reframe as rfm
 import reframe.core.logging as rflog
 import reframe.utility.sanity as sn
 
-from eessi.testsuite.constants import (ALWAYS_REQUEST_GPUS, COMPUTE_UNIT, CPU, CPU_SOCKET, DEVICE_TYPES, FEATURES, GPU,
-                                       GPU_VENDOR, GPU_VENDORS, HWTHREAD, INVALID_SYSTEM, NODE, NUMA_NODE, NVIDIA,
-                                       SCALES)
+from eessi.testsuite.constants import (COMPUTE_UNITS, DEVICE_TYPES, EXTRAS, FEATURES,
+                                       GPU_VENDORS, INVALID_SYSTEM, SCALES)
 from eessi.testsuite.utils import (get_max_avail_gpus_per_node, is_cuda_required_module, log,
                                    check_proc_attribute_defined, check_extras_key_defined)
 
@@ -70,23 +69,23 @@ def assign_tasks_per_compute_unit(test: rfm.RegressionTest, compute_unit: str, n
     Total task count is determined based on the number of nodes to be used in the test.
     Behaviour of this function is (usually) sensible for MPI tests.
 
-    WARNING: when using COMPUTE_UNIT[HWTHREAD] and invoking a hook for process binding, please verify that process
+    WARNING: when using COMPUTE_UNITS.HWTHREAD and invoking a hook for process binding, please verify that process
     binding happens correctly.
 
     Arguments:
     - test: the ReFrame test to which this hook should apply
-    - compute_unit: a device as listed in eessi.testsuite.constants.COMPUTE_UNIT
+    - compute_unit: a device as listed in eessi.testsuite.constants.COMPUTE_UNITS
 
     Examples:
     On a single node with 2 sockets, 64 cores and 128 hyperthreads:
-    - assign_tasks_per_compute_unit(test, COMPUTE_UNIT[HWTHREAD]) will launch 128 tasks with 1 thread per task
-    - assign_tasks_per_compute_unit(test, COMPUTE_UNIT[CPU]) will launch 64 tasks with 2 threads per task
-    - assign_tasks_per_compute_unit(test, COMPUTE_UNIT[CPU_SOCKET]) will launch 2 tasks with 64 threads per task
+    - assign_tasks_per_compute_unit(test, COMPUTE_UNITS.HWTHREAD) will launch 128 tasks with 1 thread per task
+    - assign_tasks_per_compute_unit(test, COMPUTE_UNITS.CPU) will launch 64 tasks with 2 threads per task
+    - assign_tasks_per_compute_unit(test, COMPUTE_UNITS.CPU_SOCKET) will launch 2 tasks with 64 threads per task
 
     """
     log(f'assign_tasks_per_compute_unit called with compute_unit: {compute_unit} and num_per: {num_per}')
 
-    if num_per != 1 and compute_unit not in [COMPUTE_UNIT[NODE]]:
+    if num_per != 1 and compute_unit not in [COMPUTE_UNITS.NODE]:
         raise NotImplementedError(
             f'Non-default num_per {num_per} is not implemented for compute_unit {compute_unit}.')
 
@@ -108,30 +107,30 @@ def assign_tasks_per_compute_unit(test: rfm.RegressionTest, compute_unit: str, n
     # If on
     # - a hyperthreading system
     # - num_cpus_per_node was set by the scale
-    # - compute_unit != COMPUTE_UNIT[HWTHREAD]
+    # - compute_unit != COMPUTE_UNITS.HWTHREAD
     # double the default_num_cpus_per_node. In this scenario, if the scale asks for e.g. 1 num_cpus_per_node and
     # the test doesn't state it wants to use hwthreads, we want to launch on two hyperthreads, i.e. one physical core
-    if SCALES[test.scale].get('num_cpus_per_node') is not None and compute_unit != COMPUTE_UNIT[HWTHREAD]:
+    if SCALES[test.scale].get('num_cpus_per_node') is not None and compute_unit != COMPUTE_UNITS.HWTHREAD:
         check_proc_attribute_defined(test, 'num_cpus_per_core')
         num_cpus_per_core = test.current_partition.processor.num_cpus_per_core
         # On a hyperthreading system?
         if num_cpus_per_core > 1:
             test.default_num_cpus_per_node = test.default_num_cpus_per_node * num_cpus_per_core
 
-    if FEATURES[GPU] in test.current_partition.features:
+    if FEATURES.GPU in test.current_partition.features:
         _assign_default_num_gpus_per_node(test)
 
-    if compute_unit == COMPUTE_UNIT[GPU]:
+    if compute_unit == COMPUTE_UNITS.GPU:
         _assign_one_task_per_gpu(test)
-    elif compute_unit == COMPUTE_UNIT[HWTHREAD]:
+    elif compute_unit == COMPUTE_UNITS.HWTHREAD:
         _assign_one_task_per_hwthread(test)
-    elif compute_unit == COMPUTE_UNIT[CPU]:
+    elif compute_unit == COMPUTE_UNITS.CPU:
         _assign_one_task_per_cpu(test)
-    elif compute_unit == COMPUTE_UNIT[CPU_SOCKET]:
+    elif compute_unit == COMPUTE_UNITS.CPU_SOCKET:
         _assign_one_task_per_cpu_socket(test)
-    elif compute_unit == COMPUTE_UNIT[NUMA_NODE]:
+    elif compute_unit == COMPUTE_UNITS.NUMA_NODE:
         _assign_one_task_per_numa_node(test)
-    elif compute_unit == COMPUTE_UNIT[NODE]:
+    elif compute_unit == COMPUTE_UNITS.NODE:
         _assign_num_tasks_per_node(test, num_per)
     else:
         raise ValueError(f'compute unit {compute_unit} is currently not supported')
@@ -466,21 +465,21 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
     """
     is_cuda_module = is_cuda_required_module(test.module_name)
 
-    if is_cuda_module and required_device_type == DEVICE_TYPES[GPU]:
-        # CUDA modules and when using a GPU require partitions with FEATURES[GPU] feature and
-        # GPU_VENDOR=GPU_VENDORS[NVIDIA] extras
-        valid_systems = f'+{FEATURES[GPU]} %{GPU_VENDOR}={GPU_VENDORS[NVIDIA]}'
+    if is_cuda_module and required_device_type == DEVICE_TYPES.GPU:
+        # CUDA modules and when using a GPU require partitions with FEATURES.GPU feature and
+        # EXTRAS.GPU_VENDOR=GPU_VENDORS.NVIDIA extras
+        valid_systems = f'+{FEATURES.GPU} %{EXTRAS.GPU_VENDOR}={GPU_VENDORS.NVIDIA}'
 
-    elif not is_cuda_module and required_device_type == DEVICE_TYPES[CPU]:
-        # Using the CPU requires partitions with FEATURES[CPU] feature
-        # Note: making FEATURES[CPU] an explicit feature allows e.g. skipping CPU-based tests on GPU partitions
-        valid_systems = f'+{FEATURES[CPU]}'
+    elif not is_cuda_module and required_device_type == DEVICE_TYPES.CPU:
+        # Using the CPU requires partitions with FEATURES.CPU feature
+        # Note: making FEATURES.CPU an explicit feature allows e.g. skipping CPU-based tests on GPU partitions
+        valid_systems = f'+{FEATURES.CPU}'
 
-    elif is_cuda_module and required_device_type == DEVICE_TYPES[CPU]:
+    elif is_cuda_module and required_device_type == DEVICE_TYPES.CPU:
         # Note: This applies for CUDA module tests that want to test only on cpus on gpu partitions.
-        valid_systems = f'+{FEATURES[CPU]} +{FEATURES[GPU]} %{GPU_VENDOR}={GPU_VENDORS[NVIDIA]}'
+        valid_systems = f'+{FEATURES.CPU} +{FEATURES.GPU} %{EXTRAS.GPU_VENDOR}={GPU_VENDORS.NVIDIA}'
 
-    elif not is_cuda_module and required_device_type == DEVICE_TYPES[GPU]:
+    elif not is_cuda_module and required_device_type == DEVICE_TYPES.GPU:
         # Invalid combination: a module without GPU support cannot use a GPU
         valid_systems = ''
 
@@ -498,7 +497,7 @@ def req_memory_per_node(test: rfm.RegressionTest, app_mem_req: float):
     Then, the hook compares this to how much memory the application claims to need per node (app_mem_req).
     It then passes the maximum of these two numbers to the batch scheduler as a memory request.
 
-    Note: using this hook requires that the ReFrame configuration defines system.partition.extras['mem_per_node']
+    Note: using this hook requires that the ReFrame configuration defines system.partition.extras[EXTRAS.MEM_PER_NODE]
     That field should be defined in GiB
 
     Arguments:
@@ -519,13 +518,13 @@ def req_memory_per_node(test: rfm.RegressionTest, app_mem_req: float):
     In this case, the test requests 50% of the CPUs. Thus, the proportional amount of memory is 64,000 MiB.
     This is higher than the app_mem_req. Thus, 64,000 MiB (per node) is requested from the batch scheduler.
     """
-    # Check that the systems.partitions.extra dict in the ReFrame config contains mem_per_node
-    check_extras_key_defined(test, 'mem_per_node')
+    # Check that the systems.partitions.extra dict in the ReFrame config contains MEM_PER_NODE
+    check_extras_key_defined(test, EXTRAS.MEM_PER_NODE)
     # Skip if the current partition doesn't have sufficient memory to run the application
-    msg = f"Skipping test: nodes in this partition only have {test.current_partition.extras['mem_per_node']} MiB"
+    msg = f"Skipping test: nodes in this partition only have {test.current_partition.extras[EXTRAS.MEM_PER_NODE]} MiB"
     msg += " memory available (per node) accodring to the current ReFrame configuration,"
     msg += f" but {app_mem_req} MiB is needed"
-    test.skip_if(test.current_partition.extras['mem_per_node'] < app_mem_req, msg)
+    test.skip_if(test.current_partition.extras[EXTRAS.MEM_PER_NODE] < app_mem_req, msg)
 
     # Check if a resource with the name 'memory' was set in the ReFrame config file. If not, warn the user
     # and return from this hook (as setting test.extra_resources will be ignored in that case according to
@@ -548,7 +547,7 @@ def req_memory_per_node(test: rfm.RegressionTest, app_mem_req: float):
     # Fraction of CPU cores requested
     check_proc_attribute_defined(test, 'num_cpus')
     cpu_fraction = test.num_tasks_per_node * test.num_cpus_per_task / test.current_partition.processor.num_cpus
-    proportional_mem = math.floor(cpu_fraction * test.current_partition.extras['mem_per_node'])
+    proportional_mem = math.floor(cpu_fraction * test.current_partition.extras[EXTRAS.MEM_PER_NODE])
     app_mem_req = math.ceil(app_mem_req)
 
     scheduler_name = test.current_partition.scheduler.registered_name
@@ -564,13 +563,13 @@ def req_memory_per_node(test: rfm.RegressionTest, app_mem_req: float):
 
         if test.exact_memory:
             # Request the exact amount of required memory
-            req_mem_per_node = app_mem_req
+            req_MEM_PER_NODE = app_mem_req
         else:
             # Request the maximum of the proportional_mem, and app_mem_req to the scheduler
-            req_mem_per_node = max(proportional_mem, app_mem_req)
+            req_MEM_PER_NODE = max(proportional_mem, app_mem_req)
 
-        test.extra_resources = {'memory': {'size': f'{req_mem_per_node}M'}}
-        log(f"Requested {req_mem_per_node} MiB per node from the SLURM batch scheduler")
+        test.extra_resources = {'memory': {'size': f'{req_MEM_PER_NODE}M'}}
+        log(f"Requested {req_MEM_PER_NODE} MiB per node from the SLURM batch scheduler")
 
     elif scheduler_name == 'torque':
         # Torque/moab requires asking for --pmem (--mem only works single node and thus doesnt generalize)
@@ -645,7 +644,7 @@ def set_compact_process_binding(test: rfm.RegressionTest):
 
     # Check if hyperthreading is enabled. If so, divide the number of cpus per task by the number
     # of hw threads per core to get a physical core count
-    # TODO: check if this also leads to sensible binding when using COMPUTE_UNIT[HWTHREAD]
+    # TODO: check if this also leads to sensible binding when using COMPUTE_UNITS.HWTHREAD
     check_proc_attribute_defined(test, 'num_cpus_per_core')
     num_cpus_per_core = test.current_partition.processor.num_cpus_per_core
     physical_cpus_per_task = int(test.num_cpus_per_task / num_cpus_per_core)
@@ -712,7 +711,7 @@ def _check_always_request_gpus(test: rfm.RegressionTest):
     if not hasattr(test, 'always_request_gpus'):
         test.always_request_gpus = False
 
-    always_request_gpus = FEATURES[ALWAYS_REQUEST_GPUS] in test.current_partition.features or test.always_request_gpus
+    always_request_gpus = FEATURES.ALWAYS_REQUEST_GPUS in test.current_partition.features or test.always_request_gpus
     if always_request_gpus and not test.num_gpus_per_node:
         test.num_gpus_per_node = test.default_num_gpus_per_node
         log(f'num_gpus_per_node set to {test.num_gpus_per_node} for partition {test.current_partition.name}')

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -563,13 +563,13 @@ def req_memory_per_node(test: rfm.RegressionTest, app_mem_req: float):
 
         if test.exact_memory:
             # Request the exact amount of required memory
-            req_MEM_PER_NODE = app_mem_req
+            req_mem_per_node = app_mem_req
         else:
             # Request the maximum of the proportional_mem, and app_mem_req to the scheduler
-            req_MEM_PER_NODE = max(proportional_mem, app_mem_req)
+            req_mem_per_node = max(proportional_mem, app_mem_req)
 
-        test.extra_resources = {'memory': {'size': f'{req_MEM_PER_NODE}M'}}
-        log(f"Requested {req_MEM_PER_NODE} MiB per node from the SLURM batch scheduler")
+        test.extra_resources = {'memory': {'size': f'{req_mem_per_node}M'}}
+        log(f"Requested {req_mem_per_node} MiB per node from the SLURM batch scheduler")
 
     elif scheduler_name == 'torque':
         # Torque/moab requires asking for --pmem (--mem only works single node and thus doesnt generalize)

--- a/eessi/testsuite/tests/apps/MetalWalls.py
+++ b/eessi/testsuite/tests/apps/MetalWalls.py
@@ -33,8 +33,7 @@ from reframe.core.builtins import run_after
 from reframe.core.parameters import TestParam as parameter
 
 from eessi.testsuite import hooks
-from eessi.testsuite.constants import (COMPUTE_UNIT, CPU, DEVICE_TYPES, GPU, CI,
-                                       SCALES, TAGS)
+from eessi.testsuite.constants import COMPUTE_UNITS, DEVICE_TYPES, SCALES, TAGS
 from eessi.testsuite.utils import find_modules, log
 
 
@@ -54,8 +53,8 @@ class EESSI_MetalWalls_MW(MetalWallsCheck):
 
     module_name = parameter(find_modules('MetalWalls'))
     # For now, MetalWalls is being build for CPU targets only
-    # compute_device = parameter([DEVICE_TYPES[CPU], DEVICE_TYPES[GPU]])
-    compute_device = parameter([DEVICE_TYPES[CPU], ])
+    # compute_device = parameter([DEVICE_TYPES.CPU], DEVICE_TYPES.GPU)
+    compute_device = parameter([DEVICE_TYPES.CPU], )
 
     @run_after('init')
     def run_after_init(self):
@@ -79,7 +78,7 @@ class EESSI_MetalWalls_MW(MetalWallsCheck):
     def set_tag_ci(self):
         """Set tag CI on smallest benchmark, so it can be selected on the cmd line via --tag CI"""
         if self.benchmark_info[0] == 'hackathonGPU/benchmark':
-            self.tags.add(TAGS[CI])
+            self.tags.add(TAGS.CI)
             log(f'tags set to {self.tags}')
 
     @run_after('init')
@@ -97,10 +96,10 @@ class EESSI_MetalWalls_MW(MetalWallsCheck):
         # Calculate default requested resources based on the scale:
         # 1 task per CPU for CPU-only tests, 1 task per GPU for GPU tests.
         # Also support setting the resources on the cmd line.
-        if self.compute_device == DEVICE_TYPES[GPU]:
-            hooks.assign_tasks_per_compute_unit(test=self, compute_unit=COMPUTE_UNIT[GPU])
+        if self.compute_device == DEVICE_TYPES.GPU:
+            hooks.assign_tasks_per_compute_unit(test=self, compute_unit=COMPUTE_UNITS.GPU)
         else:
-            hooks.assign_tasks_per_compute_unit(test=self, compute_unit=COMPUTE_UNIT[CPU])
+            hooks.assign_tasks_per_compute_unit(test=self, compute_unit=COMPUTE_UNITS.CPU)
 
     @run_after('setup')
     def set_binding(self):

--- a/eessi/testsuite/tests/apps/MetalWalls.py
+++ b/eessi/testsuite/tests/apps/MetalWalls.py
@@ -53,8 +53,8 @@ class EESSI_MetalWalls_MW(MetalWallsCheck):
 
     module_name = parameter(find_modules('MetalWalls'))
     # For now, MetalWalls is being build for CPU targets only
-    # compute_device = parameter([DEVICE_TYPES.CPU], DEVICE_TYPES.GPU)
-    compute_device = parameter([DEVICE_TYPES.CPU], )
+    # compute_device = parameter([DEVICE_TYPES.CPU, DEVICE_TYPES.GPU])
+    compute_device = parameter([DEVICE_TYPES.CPU])
 
     @run_after('init')
     def run_after_init(self):

--- a/eessi/testsuite/tests/apps/PyTorch/PyTorch_torchvision.py
+++ b/eessi/testsuite/tests/apps/PyTorch/PyTorch_torchvision.py
@@ -4,7 +4,7 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 from reframe.core.builtins import parameter, run_after, sanity_function, performance_function
 
-from eessi.testsuite.constants import DEVICE_TYPES, COMPUTE_UNIT, CPU, NUMA_NODE, GPU
+from eessi.testsuite.constants import DEVICE_TYPES, COMPUTE_UNITS
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 from eessi.testsuite.utils import find_modules
 
@@ -31,7 +31,7 @@ class EESSI_PyTorch_torchvision(rfm.RunOnlyRegressionTest, EESSI_Mixin):
         self.bench_name = self.nn_model
 
         # If not a GPU run, disable CUDA
-        if self.device_type != DEVICE_TYPES[GPU]:
+        if self.device_type != DEVICE_TYPES.GPU:
             self.executable_opts += ['--no-cuda']
 
     @run_after('setup')
@@ -73,7 +73,7 @@ class EESSI_PyTorch_torchvision(rfm.RunOnlyRegressionTest, EESSI_Mixin):
     @performance_function('img/sec')
     def througput_per_CPU(self):
         '''Training througput per device type'''
-        if self.device_type == DEVICE_TYPES[CPU]:
+        if self.device_type == DEVICE_TYPES.CPU:
             return sn.extractsingle(r'Img/sec per CPU:\s+(?P<perf_per_cpu>\S+)', self.stdout, 'perf_per_cpu', float)
         else:
             return sn.extractsingle(r'Img/sec per GPU:\s+(?P<perf_per_gpu>\S+)', self.stdout, 'perf_per_gpu', float)
@@ -81,14 +81,14 @@ class EESSI_PyTorch_torchvision(rfm.RunOnlyRegressionTest, EESSI_Mixin):
 
 @rfm.simple_test
 class EESSI_PyTorch_torchvision_CPU(EESSI_PyTorch_torchvision):
-    device_type = DEVICE_TYPES[CPU]
-    compute_unit = COMPUTE_UNIT[NUMA_NODE]
+    device_type = DEVICE_TYPES.CPU
+    compute_unit = COMPUTE_UNITS.NUMA_NODE
 
 
 @rfm.simple_test
 class EESSI_PyTorch_torchvision_GPU(EESSI_PyTorch_torchvision):
-    device_type = DEVICE_TYPES[GPU]
-    compute_unit = COMPUTE_UNIT[GPU]
+    device_type = DEVICE_TYPES.GPU
+    compute_unit = COMPUTE_UNITS.GPU
     precision = parameter(['default', 'mixed'])
 
     @run_after('init')

--- a/eessi/testsuite/tests/apps/QuantumESPRESSO.py
+++ b/eessi/testsuite/tests/apps/QuantumESPRESSO.py
@@ -32,7 +32,7 @@ import reframe as rfm
 from hpctestlib.sciapps.qespresso.benchmarks import QEspressoPWCheck
 from reframe.core.builtins import parameter, run_after
 
-from eessi.testsuite.constants import COMPUTE_UNIT, CPU, DEVICE_TYPES, GPU
+from eessi.testsuite.constants import COMPUTE_UNITS, DEVICE_TYPES
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 from eessi.testsuite.utils import find_modules
 
@@ -42,7 +42,7 @@ class EESSI_QuantumESPRESSO_PW(QEspressoPWCheck, EESSI_Mixin):
     time_limit = '30m'
     module_name = parameter(find_modules('QuantumESPRESSO'))
     # For now, QE is built for CPU targets only
-    device_type = parameter([DEVICE_TYPES[CPU]])
+    device_type = parameter([DEVICE_TYPES.CPU])
     readonly_files = ['']
 
     def required_mem_per_node(self):
@@ -71,7 +71,7 @@ class EESSI_QuantumESPRESSO_PW(QEspressoPWCheck, EESSI_Mixin):
         one task per CPU core for CPU runs, and one task per GPU for GPU runs.
         """
         device_to_compute_unit = {
-            DEVICE_TYPES[CPU]: COMPUTE_UNIT[CPU],
-            DEVICE_TYPES[GPU]: COMPUTE_UNIT[GPU],
+            DEVICE_TYPES.CPU: COMPUTE_UNITS.CPU,
+            DEVICE_TYPES.GPU: COMPUTE_UNITS.GPU,
         }
         self.compute_unit = device_to_compute_unit.get(self.device_type)

--- a/eessi/testsuite/tests/apps/cp2k/cp2k.py
+++ b/eessi/testsuite/tests/apps/cp2k/cp2k.py
@@ -2,7 +2,7 @@ import reframe as rfm
 from reframe.core.builtins import parameter, run_after, performance_function, sanity_function
 import reframe.utility.sanity as sn
 
-from eessi.testsuite.constants import SCALES, COMPUTE_UNIT, DEVICE_TYPES, CPU
+from eessi.testsuite.constants import SCALES, COMPUTE_UNITS, DEVICE_TYPES
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 from eessi.testsuite.utils import find_modules
 
@@ -22,8 +22,8 @@ class EESSI_CP2K(rfm.RunOnlyRegressionTest, EESSI_Mixin):
 
     executable = 'cp2k.popt'
     time_limit = '2h'
-    device_type = DEVICE_TYPES[CPU]
-    compute_unit = COMPUTE_UNIT[CPU]
+    device_type = DEVICE_TYPES.CPU
+    compute_unit = COMPUTE_UNITS.CPU
     bench_name_ci = 'QS/H2O-32'  # set CI on smallest benchmark
     readonly_files = ['QS']
 

--- a/eessi/testsuite/tests/apps/espresso/espresso.py
+++ b/eessi/testsuite/tests/apps/espresso/espresso.py
@@ -13,7 +13,7 @@ import reframe.utility.sanity as sn
 from reframe.core.builtins import deferrable, parameter, performance_function, run_after, sanity_function
 from reframe.utility import reframe
 
-from eessi.testsuite.constants import CPU, DEVICE_TYPES, SCALES, COMPUTE_UNIT
+from eessi.testsuite.constants import DEVICE_TYPES, SCALES, COMPUTE_UNITS
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 from eessi.testsuite.utils import find_modules, log
 
@@ -33,8 +33,8 @@ def filter_scales():
 
 class EESSI_ESPRESSO_base(rfm.RunOnlyRegressionTest):
     module_name = parameter(find_modules('^ESPResSo$'))
-    device_type = DEVICE_TYPES[CPU]
-    compute_unit = COMPUTE_UNIT[CPU]
+    device_type = DEVICE_TYPES.CPU
+    compute_unit = COMPUTE_UNITS.CPU
     time_limit = '300m'
 
     @run_after('init')
@@ -111,7 +111,7 @@ class EESSI_ESPRESSO_LJ_PARTICLES(EESSI_ESPRESSO_base, EESSI_Mixin):
     @deferrable
     def assert_completion(self):
         '''Check completion'''
-        return (sn.assert_found(r'^Algorithm executed.', self.stdout))
+        return sn.assert_found(r'^Algorithm executed.', self.stdout)
 
     @deferrable
     def assert_convergence(self):

--- a/eessi/testsuite/tests/apps/gromacs.py
+++ b/eessi/testsuite/tests/apps/gromacs.py
@@ -34,7 +34,7 @@ from reframe.core.builtins import parameter, run_after  # added only to make the
 
 from hpctestlib.sciapps.gromacs.benchmarks import gromacs_check
 
-from eessi.testsuite.constants import COMPUTE_UNIT, DEVICE_TYPES, SCALES
+from eessi.testsuite.constants import COMPUTE_UNITS, DEVICE_TYPES, SCALES
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 from eessi.testsuite.utils import find_modules, log
 
@@ -69,12 +69,12 @@ class EESSI_GROMACS(EESSI_GROMACS_base, EESSI_Mixin):
         Set the compute unit to which tasks will be assigned:
         one task per CPU core for CPU runs, and one task per GPU for GPU runs.
         """
-        if self.device_type == DEVICE_TYPES['CPU']:
-            self.compute_unit = COMPUTE_UNIT['CPU']
-        elif self.device_type == DEVICE_TYPES['GPU']:
-            self.compute_unit = COMPUTE_UNIT['GPU']
+        if self.device_type == DEVICE_TYPES.CPU:
+            self.compute_unit = COMPUTE_UNITS.CPU
+        elif self.device_type == DEVICE_TYPES.GPU:
+            self.compute_unit = COMPUTE_UNITS.GPU
         else:
-            msg = f"No mapping of device type {self.device_type} to a COMPUTE_UNIT was specified in this test"
+            msg = f"No mapping of device type {self.device_type} to a COMPUTE_UNITS was specified in this test"
             raise NotImplementedError(msg)
 
     @run_after('setup')

--- a/eessi/testsuite/tests/apps/lammps/lammps.py
+++ b/eessi/testsuite/tests/apps/lammps/lammps.py
@@ -8,13 +8,13 @@ from reframe.core.builtins import deferrable, parameter, performance_function, r
 import reframe.utility.sanity as sn
 
 from eessi.testsuite import utils
-from eessi.testsuite.constants import CI, COMPUTE_UNIT, CPU, DEVICE_TYPES, GPU, TAGS
+from eessi.testsuite.constants import COMPUTE_UNITS, DEVICE_TYPES, TAGS
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 
 
 class EESSI_LAMMPS_base(rfm.RunOnlyRegressionTest):
     time_limit = '30m'
-    device_type = parameter([DEVICE_TYPES[CPU], DEVICE_TYPES[GPU]])
+    device_type = parameter([DEVICE_TYPES.CPU], DEVICE_TYPES.GPU)
 
     # Parameterize over all modules that start with LAMMPS
     module_name = parameter(utils.find_modules('LAMMPS'))
@@ -53,18 +53,18 @@ class EESSI_LAMMPS_base(rfm.RunOnlyRegressionTest):
     @run_after('init')
     def set_compute_unit(self):
         """Set the compute unit to which tasks will be assigned """
-        if self.device_type == 'cpu':
-            self.compute_unit = COMPUTE_UNIT['CPU']
-        elif self.device_type == 'gpu':
-            self.compute_unit = COMPUTE_UNIT['GPU']
+        if self.device_type == DEVICE_TYPES.CPU:
+            self.compute_unit = COMPUTE_UNITS.CPU
+        elif self.device_type == DEVICE_TYPES.GPU:
+            self.compute_unit = COMPUTE_UNITS.GPU
         else:
-            msg = f"No mapping of device type {self.device_type} to a COMPUTE_UNIT was specified in this test"
+            msg = f"No mapping of device type {self.device_type} to a COMPUTE_UNITS was specified in this test"
             raise NotImplementedError(msg)
 
 
 @rfm.simple_test
 class EESSI_LAMMPS_lj(EESSI_LAMMPS_base, EESSI_Mixin):
-    tags = {TAGS[CI]}
+    tags = {TAGS.CI}
 
     sourcesdir = 'src/lj'
     readonly_files = ['in.lj']
@@ -106,7 +106,7 @@ class EESSI_LAMMPS_lj(EESSI_LAMMPS_base, EESSI_Mixin):
         """Set executable opts based on device_type parameter"""
         # should also check if LAMMPS is installed with kokkos.
         # Because this executable opt is only for that case.
-        if self.device_type == "gpu":
+        if self.device_type == DEVICE_TYPES.GPU:
             if 'kokkos' in self.module_name:
                 self.executable_opts += [
                     f'-kokkos on t {self.num_cpus_per_task} g {self.num_gpus_per_node}',
@@ -161,7 +161,7 @@ class EESSI_LAMMPS_rhodo(EESSI_LAMMPS_base, EESSI_Mixin):
         """Set executable opts based on device_type parameter"""
         # should also check if the lammps is installed with kokkos.
         # Because this executable opt is only for that case.
-        if self.device_type == "gpu":
+        if self.device_type == DEVICE_TYPES.GPU:
             if 'kokkos' in self.module_name:
                 self.executable_opts += [
                     f'-kokkos on t {self.num_cpus_per_task} g {self.num_gpus_per_node}',

--- a/eessi/testsuite/tests/apps/lammps/lammps.py
+++ b/eessi/testsuite/tests/apps/lammps/lammps.py
@@ -14,7 +14,7 @@ from eessi.testsuite.eessi_mixin import EESSI_Mixin
 
 class EESSI_LAMMPS_base(rfm.RunOnlyRegressionTest):
     time_limit = '30m'
-    device_type = parameter([DEVICE_TYPES.CPU], DEVICE_TYPES.GPU)
+    device_type = parameter([DEVICE_TYPES.CPU, DEVICE_TYPES.GPU])
 
     # Parameterize over all modules that start with LAMMPS
     module_name = parameter(utils.find_modules('LAMMPS'))

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -11,7 +11,7 @@ from reframe.utility import reframe
 
 from hpctestlib.microbenchmarks.mpi.osu import osu_benchmark
 
-from eessi.testsuite.constants import COMPUTE_UNIT, CPU, DEVICE_TYPES, INVALID_SYSTEM, GPU, NODE, SCALES
+from eessi.testsuite.constants import COMPUTE_UNITS, DEVICE_TYPES, INVALID_SYSTEM, SCALES
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 from eessi.testsuite.utils import find_modules, log
 
@@ -75,7 +75,7 @@ class EESSI_OSU_Base(osu_benchmark):
     def filter_scales_2gpus(self):
         """Filter out scales with < 2 GPUs if running on GPUs"""
         if (
-            self.device_type == DEVICE_TYPES[GPU]
+            self.device_type == DEVICE_TYPES.GPU
             and SCALES[self.scale]['num_nodes'] == 1
             and SCALES[self.scale].get('num_gpus_per_node', 2) < 2
         ):
@@ -89,7 +89,7 @@ class EESSI_OSU_Base(osu_benchmark):
         commands in a @run_before('setup') hook if not equal to 'cpu'.
         Therefore, we must set device_buffers *before* the @run_before('setup') hooks.
         """
-        if self.device_type == DEVICE_TYPES[GPU]:
+        if self.device_type == DEVICE_TYPES.GPU:
             self.device_buffers = 'cuda'
         else:
             self.device_buffers = 'cpu'
@@ -103,7 +103,7 @@ class EESSI_OSU_Base(osu_benchmark):
 
 class EESSI_OSU_pt2pt_Base(EESSI_OSU_Base):
     ''' point-to-point OSU test base class '''
-    compute_unit = COMPUTE_UNIT[NODE]
+    compute_unit = COMPUTE_UNITS.NODE
 
     @run_after('init')
     def filter_benchmark_pt2pt(self):
@@ -130,7 +130,7 @@ class EESSI_OSU_pt2pt_Base(EESSI_OSU_Base):
         This option is added by hpctestlib in a @run_before('setup') to all pt2pt tests which is not required.
         Therefore we must override it *after* the 'setup' phase
         """
-        if self.device_type == DEVICE_TYPES[CPU]:
+        if self.device_type == DEVICE_TYPES.CPU:
             self.executable_opts = [x for x in self.executable_opts if x != 'D']
 
 
@@ -138,14 +138,14 @@ class EESSI_OSU_pt2pt_Base(EESSI_OSU_Base):
 class EESSI_OSU_pt2pt_CPU(EESSI_OSU_pt2pt_Base, EESSI_Mixin):
     ''' point-to-point OSU test on CPUs'''
     scale = parameter(filter_scales_pt2pt_cpu())
-    device_type = DEVICE_TYPES[CPU]
+    device_type = DEVICE_TYPES.CPU
 
 
 @rfm.simple_test
 class EESSI_OSU_pt2pt_GPU(EESSI_OSU_pt2pt_Base, EESSI_Mixin):
     ''' point-to-point OSU test on GPUs'''
     scale = parameter(filter_scales_pt2pt_gpu())
-    device_type = DEVICE_TYPES[GPU]
+    device_type = DEVICE_TYPES.GPU
     always_request_gpus = True
 
     @run_after('setup')
@@ -166,7 +166,7 @@ class EESSI_OSU_pt2pt_GPU(EESSI_OSU_pt2pt_Base, EESSI_Mixin):
 class EESSI_OSU_coll(EESSI_OSU_Base, EESSI_Mixin):
     ''' collective OSU test '''
     scale = parameter(filter_scales_coll())
-    device_type = parameter([DEVICE_TYPES[CPU], DEVICE_TYPES[GPU]])
+    device_type = parameter([DEVICE_TYPES.CPU], DEVICE_TYPES.GPU)
 
     @run_after('init')
     def filter_benchmark_coll(self):
@@ -187,13 +187,13 @@ class EESSI_OSU_coll(EESSI_OSU_Base, EESSI_Mixin):
         one task per core for CPU runs, and one task per GPU for GPU runs.
         """
         device_to_compute_unit = {
-            DEVICE_TYPES[CPU]: COMPUTE_UNIT[CPU],
-            DEVICE_TYPES[GPU]: COMPUTE_UNIT[GPU],
+            DEVICE_TYPES.CPU: COMPUTE_UNITS.CPU,
+            DEVICE_TYPES.GPU: COMPUTE_UNITS.GPU,
         }
         self.compute_unit = device_to_compute_unit.get(self.device_type)
 
     @run_after('setup')
     def skip_test_1gpu(self):
-        if self.device_type == DEVICE_TYPES[GPU]:
+        if self.device_type == DEVICE_TYPES.GPU:
             num_gpus = self.num_gpus_per_node * self.num_nodes
             self.skip_if(num_gpus < 2, "Skipping GPU test : only 1 GPU available for this test case")

--- a/eessi/testsuite/tests/apps/osu.py
+++ b/eessi/testsuite/tests/apps/osu.py
@@ -166,7 +166,7 @@ class EESSI_OSU_pt2pt_GPU(EESSI_OSU_pt2pt_Base, EESSI_Mixin):
 class EESSI_OSU_coll(EESSI_OSU_Base, EESSI_Mixin):
     ''' collective OSU test '''
     scale = parameter(filter_scales_coll())
-    device_type = parameter([DEVICE_TYPES.CPU], DEVICE_TYPES.GPU)
+    device_type = parameter([DEVICE_TYPES.CPU, DEVICE_TYPES.GPU])
 
     @run_after('init')
     def filter_benchmark_coll(self):

--- a/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
+++ b/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
@@ -20,7 +20,7 @@ class EESSI_TensorFlow(rfm.RunOnlyRegressionTest, EESSI_Mixin):
     module_name = parameter(utils.find_modules('TensorFlow'))
 
     # Make CPU and GPU versions of this test
-    device_type = parameter([DEVICE_TYPES.CPU], DEVICE_TYPES.GPU)
+    device_type = parameter([DEVICE_TYPES.CPU, DEVICE_TYPES.GPU])
 
     executable = 'python tf_test.py'
     readonly_files = ['mnist_setup.py', 'tf_test.py']

--- a/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
+++ b/eessi/testsuite/tests/apps/tensorflow/tensorflow.py
@@ -9,7 +9,7 @@ from reframe.core.builtins import deferrable, parameter, run_after, sanity_funct
 import reframe.utility.sanity as sn
 
 from eessi.testsuite import utils
-from eessi.testsuite.constants import COMPUTE_UNIT, CPU, CPU_SOCKET, DEVICE_TYPES, GPU
+from eessi.testsuite.constants import COMPUTE_UNITS, DEVICE_TYPES
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
 
 
@@ -20,7 +20,7 @@ class EESSI_TensorFlow(rfm.RunOnlyRegressionTest, EESSI_Mixin):
     module_name = parameter(utils.find_modules('TensorFlow'))
 
     # Make CPU and GPU versions of this test
-    device_type = parameter([DEVICE_TYPES[CPU], DEVICE_TYPES[GPU]])
+    device_type = parameter([DEVICE_TYPES.CPU], DEVICE_TYPES.GPU)
 
     executable = 'python tf_test.py'
     readonly_files = ['mnist_setup.py', 'tf_test.py']
@@ -86,8 +86,8 @@ class EESSI_TensorFlow(rfm.RunOnlyRegressionTest, EESSI_Mixin):
         one task per CPU socket for CPU runs, and one task per GPU for GPU runs.
         """
         device_to_compute_unit = {
-            DEVICE_TYPES[CPU]: COMPUTE_UNIT[CPU_SOCKET],
-            DEVICE_TYPES[GPU]: COMPUTE_UNIT[GPU],
+            DEVICE_TYPES.CPU: COMPUTE_UNITS.CPU_SOCKET,
+            DEVICE_TYPES.GPU: COMPUTE_UNITS.GPU,
         }
         self.compute_unit = device_to_compute_unit.get(self.device_type)
 

--- a/eessi/testsuite/utils.py
+++ b/eessi/testsuite/utils.py
@@ -21,7 +21,7 @@ def log(msg, logger=printer.debug):
 
 
 def _get_gpu_list(test: rfm.RegressionTest) -> list:
-    return [dev.num_devices for dev in test.current_partition.devices if dev.device_type == DEVICE_TYPES[GPU]]
+    return [dev.num_devices for dev in test.current_partition.devices if dev.device_type == DEVICE_TYPES.GPU]
 
 
 def get_max_avail_gpus_per_node(test: rfm.RegressionTest) -> int:
@@ -30,12 +30,12 @@ def get_max_avail_gpus_per_node(test: rfm.RegressionTest) -> int:
     taken from 'num_devices' of device GPU_DEV_NAME in the 'devices' attribute of the current partition
     """
     gpu_list = _get_gpu_list(test)
-    # If multiple devices have type DEVICE_TYPES[GPU] in the current partition,
+    # If multiple devices have type DEVICE_TYPES.GPU in the current partition,
     # we don't know for which to return the device count...
     if len(gpu_list) != 1:
         partname = test.current_partition.name
         raise ValueError(
-            f"{len(gpu_list)} devices defined in config file with name {DEVICE_TYPES[GPU]} for partition {partname}. "
+            f"{len(gpu_list)} devices defined in config file with name {DEVICE_TYPES.GPU} for partition {partname}. "
             "Cannot determine maximum number of GPUs available for the test. "
             f"Please check the definition of partition {partname} in your ReFrame config file."
         )

--- a/tutorial/mpi4py/mpi4py_portable_legacy.py
+++ b/tutorial/mpi4py/mpi4py_portable_legacy.py
@@ -9,7 +9,7 @@ import reframe.utility.sanity as sn
 from reframe.core.builtins import variable, parameter, run_after, performance_function, sanity_function
 
 from eessi.testsuite import hooks
-from eessi.testsuite.constants import SCALES, COMPUTE_UNIT, CPU
+from eessi.testsuite.constants import SCALES, COMPUTE_UNITS
 from eessi.testsuite.utils import find_modules
 
 
@@ -88,7 +88,7 @@ class EESSI_MPI4PY(rfm.RunOnlyRegressionTest):
         """ Setting number of tasks per node and cpus per task in this function. This function sets
         num_tasks, num_tasks_per_node, num_cpus_per_task, and num_gpus_per_node, based on the current scale
         and the current partition's num_cpus, max_avail_gpus_per_node and num_nodes"""
-        hooks.assign_tasks_per_compute_unit(self, COMPUTE_UNIT[CPU])
+        hooks.assign_tasks_per_compute_unit(self, COMPUTE_UNITS.CPU)
 
         # This test scales almost indefinitely
         # For tests that have limited scaling, make sure that test instances exceeding

--- a/tutorial/mpi4py/mpi4py_portable_mixin.py
+++ b/tutorial/mpi4py/mpi4py_portable_mixin.py
@@ -10,7 +10,7 @@ from reframe.core.builtins import variable, parameter, performance_function, san
 
 # Import the EESSI_Mixin class so that we can inherit from it
 from eessi.testsuite.eessi_mixin import EESSI_Mixin
-from eessi.testsuite.constants import COMPUTE_UNIT, DEVICE_TYPES, CPU
+from eessi.testsuite.constants import COMPUTE_UNITS, DEVICE_TYPES
 from eessi.testsuite.utils import find_modules
 
 
@@ -21,10 +21,10 @@ from eessi.testsuite.utils import find_modules
 class EESSI_MPI4PY(rfm.RunOnlyRegressionTest, EESSI_Mixin):
 
     # The device type makes sure this test only gets executed on systems/partitions that can provide this device
-    device_type = DEVICE_TYPES[CPU]
+    device_type = DEVICE_TYPES.CPU
 
     # One task is launched per compute unit. In this case, one task per (physical) CPU core
-    compute_unit = COMPUTE_UNIT[CPU]
+    compute_unit = COMPUTE_UNITS.CPU
 
     # ReFrame will generate a test for each module that matches the regex `mpi4py`
     # This means we implicitly assume that any module matching this name provides the required functionality


### PR DESCRIPTION
fixes https://github.com/EESSI/test-suite/issues/257

also:
- add constant for `extras` key `'mem_per_node'`
- group `extras` constants into `EXTRAS` namedtuple: `EXTRAS.GPU_VENDOR`, `EXTRAS.MEM_PER_NODE`
- change `EESSI_mixin_validate_item_in_dict` method to `EESSI_mixin_validate_item_in_list` to make it simpler and more flexible