### PR TITLE
Bump ubuntu versions and disable python 3.6 tests

### DIFF
--- a/.github/workflows/automatic_versioning.yml
+++ b/.github/workflows/automatic_versioning.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
 #         - name: Check out repository
 #           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/automatic_versioning.yml
+++ b/.github/workflows/automatic_versioning.yml
@@ -4,8 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions: read-all
 jobs:
   test_versioning_from_tarball:
-    # ubuntu <= 20.04 is required for python 3.6
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check_versions.yml
+++ b/.github/workflows/check_versions.yml
@@ -4,8 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions: read-all
 jobs:
   test_fallback_version_against_tags:
-    # ubuntu <= 20.04 is required for python 3.6
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/pip_install.yml
+++ b/.github/workflows/pip_install.yml
@@ -4,12 +4,11 @@ on: [push, pull_request, workflow_dispatch]
 permissions: read-all
 jobs:
   test_pip_install:
-    # ubuntu <= 20.04 is required for python 3.6
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
         - name: Check out repository
           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
Fixes https://github.com/EESSI/test-suite/issues/251 

But means we don't support python 3.6 anymore. We can reintroduce tests for Python 3.6 later by running an Ubuntu 20 based container in an Ubuntu 22 based runner (similar to https://github.com/easybuilders/easybuild-framework/pull/4783 ), but I don't have time to fix that right now (and I doubt I can prioritize it in the near future).
