### PR TITLE
Fix output of full_modulepath

### DIFF
--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -203,7 +203,7 @@ class EESSI_Mixin(RegressionMixin):
         self.postrun_cmds.append('echo "EESSI_SOFTWARE_SUBDIR: $EESSI_SOFTWARE_SUBDIR"')
         if self.module_name:
             # Get full modulepath
-            get_full_modpath = f'echo "FULL_MODULEPATH: $(module --location show {self.module_name})"'
+            get_full_modpath = f'echo "FULL_MODULEPATH: $(module --location show {self.module_name} 2>&1)"'
             self.postrun_cmds.append(get_full_modpath)
 
     @run_before('run', always_last=True)


### PR DESCRIPTION
Noticed that `module --location show PyTorch/2.1.2-foss-2023a` was returning nothing in stdout. Which ment that the full modulepath was missing from the report-file
```
"full_modulepath": "['']",
```

This is because the module command prints to stderr when `LMOD_REDIRECT=no` which is the case for EESSI. This small fix makes sure that `full_modulepath` will be set either way. 