### PR TITLE
Blas test: change to use the new launcher keyword

### DIFF
--- a/eessi/testsuite/tests/libs/blas/blas.py
+++ b/eessi/testsuite/tests/libs/blas/blas.py
@@ -23,7 +23,6 @@ Supported tags in this ReFrame test (in addition to the common tags):
 
 
 import reframe as rfm
-from reframe.core.backends import getlauncher
 from reframe.core.builtins import parameter, run_after, run_before, sanity_function
 import reframe.core.logging as rflog
 import reframe.utility.sanity as sn

--- a/eessi/testsuite/tests/libs/blas/blas.py
+++ b/eessi/testsuite/tests/libs/blas/blas.py
@@ -108,6 +108,8 @@ class EESSI_BLAS_base(rfm.RunOnlyRegressionTest):
     size = ['200', '2000', '200']
     require_buildenv_module = True
     threading = 'mt'
+    thread_binding = 'compact'
+    launcher = 'local'  # No MPI module is loaded in this test
 
     def required_mem_per_node(self):
         return self.num_cpus_per_task * 100 + 250
@@ -178,7 +180,6 @@ class EESSI_BLAS_OpenBLAS_mt(EESSI_BLAS_base, EESSI_Mixin):
     flexiblas_blas_lib = 'openblas'
     tags = {'openblas'}
     is_ci_test = True
-    thread_binding = 'compact'
 
 
 @rfm.simple_test
@@ -189,7 +190,6 @@ class EESSI_BLAS_AOCLBLAS_mt(EESSI_BLAS_base, EESSI_Mixin):
     module_name = parameter(get_blas_modules('AOCL-BLAS'))
     flexiblas_blas_lib = 'aocl_mt'
     tags = {'aocl-blas'}
-    thread_binding = 'compact'
 
 
 @rfm.simple_test
@@ -200,7 +200,6 @@ class EESSI_BLAS_imkl_mt(EESSI_BLAS_base, EESSI_Mixin):
     module_name = parameter(get_imkl_modules())
     flexiblas_blas_lib = 'imkl'
     tags = {'imkl'}
-    thread_binding = 'compact'
 
 
 class EESSI_BLAS_BLIS_mt(EESSI_BLAS_base, EESSI_Mixin):
@@ -210,4 +209,3 @@ class EESSI_BLAS_BLIS_mt(EESSI_BLAS_base, EESSI_Mixin):
     module_name = parameter(get_blas_modules('BLIS'))
     flexiblas_blas_lib = 'blis'
     tags = {'blis'}
-    thread_binding = 'compact'

--- a/eessi/testsuite/tests/libs/blas/blas.py
+++ b/eessi/testsuite/tests/libs/blas/blas.py
@@ -108,7 +108,6 @@ class EESSI_BLAS_base(rfm.RunOnlyRegressionTest):
     size = ['200', '2000', '200']
     require_buildenv_module = True
     threading = 'mt'
-    thread_binding = 'compact'
     launcher = 'local'  # No MPI module is loaded in this test
 
     def required_mem_per_node(self):
@@ -180,6 +179,7 @@ class EESSI_BLAS_OpenBLAS_mt(EESSI_BLAS_base, EESSI_Mixin):
     flexiblas_blas_lib = 'openblas'
     tags = {'openblas'}
     is_ci_test = True
+    thread_binding = 'compact'
 
 
 @rfm.simple_test
@@ -190,6 +190,7 @@ class EESSI_BLAS_AOCLBLAS_mt(EESSI_BLAS_base, EESSI_Mixin):
     module_name = parameter(get_blas_modules('AOCL-BLAS'))
     flexiblas_blas_lib = 'aocl_mt'
     tags = {'aocl-blas'}
+    thread_binding = 'compact'
 
 
 @rfm.simple_test
@@ -200,6 +201,7 @@ class EESSI_BLAS_imkl_mt(EESSI_BLAS_base, EESSI_Mixin):
     module_name = parameter(get_imkl_modules())
     flexiblas_blas_lib = 'imkl'
     tags = {'imkl'}
+    thread_binding = 'compact'
 
 
 class EESSI_BLAS_BLIS_mt(EESSI_BLAS_base, EESSI_Mixin):
@@ -209,3 +211,4 @@ class EESSI_BLAS_BLIS_mt(EESSI_BLAS_base, EESSI_Mixin):
     module_name = parameter(get_blas_modules('BLIS'))
     flexiblas_blas_lib = 'blis'
     tags = {'blis'}
+    thread_binding = 'compact'

--- a/eessi/testsuite/tests/libs/blas/blas.py
+++ b/eessi/testsuite/tests/libs/blas/blas.py
@@ -136,11 +136,6 @@ class EESSI_BLAS_base(rfm.RunOnlyRegressionTest):
             'FLEXIBLAS': self.flexiblas_blas_lib,
         })
 
-    @run_after('setup')
-    def set_launcher(self):
-        """Select local launcher"""
-        self.job.launcher = getlauncher('local')()
-
     @sanity_function
     def assert_sanity(self):
         assert_backend = sn.assert_not_found(


### PR DESCRIPTION
And move the `thread_binding` to the base class, as it is the same for all inherited classes.