### PR TITLE
Fix that more than 1 node is allocated for intra-node OSU bandwidth test

### DIFF
--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -43,6 +43,9 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': [common_eessi_init()],
                     'launcher': 'mpirun',
+                    'sched_options': {
+                        'use_nodes_option': True,
+                    },
                     'access': ['-p rome', '--export=None'],
                     'environs': ['default'],
                     'max_jobs': 120,
@@ -72,6 +75,9 @@ site_configuration = {
                         common_eessi_init()
                     ],
                     'launcher': 'mpirun',
+                    'sched_options': {
+                        'use_nodes_option': True,
+                    },
                     'access': ['-p genoa', '--export=None'],
                     'environs': ['default'],
                     'max_jobs': 120,
@@ -96,6 +102,9 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': [common_eessi_init()],
                     'launcher': 'mpirun',
+                    'sched_options': {
+                        'use_nodes_option': True,
+                    },
                     'access': ['-p gpu_a100', '--export=None'],
                     'environs': ['default'],
                     'max_jobs': 60,
@@ -132,6 +141,9 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'prepare_cmds': [common_eessi_init()],
                     'launcher': 'mpirun',
+                    'sched_options': {
+                        'use_nodes_option': True,
+                    },
                     'access': ['-p gpu_h100', '--export=None'],
                     'environs': ['default'],
                     'max_jobs': 60,


### PR DESCRIPTION
Set the use_nodes_option to prevent SLURM from allocating e.g. 2 nodes when --ntasks 2 --ntasks-per-node 2 is set.

Should fix https://github.com/EESSI/test-suite/issues/291, but let's see...