### PR TITLE
Remove pkg_resources usage

### DIFF
--- a/.github/workflows/pip_install.yml
+++ b/.github/workflows/pip_install.yml
@@ -27,6 +27,8 @@ jobs:
               # system installed setuptools version in RHEL8 and CO7
               python -m pip install --user setuptools==39.2.0
             fi
+            echo "Setuptools version:"
+            python -c "import setuptools; print(setuptools.__version__)"
 
         - name: Install ReFrame
           run: |

--- a/eessi/__init__.py
+++ b/eessi/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ elif python_version >= (3, 6) and current_setuptools_version >= pkg_resources.pa
 scm_dict['fallback_version'] = get_version_by_import()
 
 setuptools.setup(
-    packages=find_namespace_package(include="eessi*")
+    packages=find_namespace_package(include="eessi*"),
     use_scm_version=scm_dict,
     setup_requires=[setuptools_scm_requirement],
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ elif python_version >= (3, 6) and current_setuptools_version >= pkg_resources.pa
 scm_dict['fallback_version'] = get_version_by_import()
 
 setuptools.setup(
-    packages=find_namespace_package(include="eessi*"),
+    packages=find_namespace_packages(include="eessi*"),
     use_scm_version=scm_dict,
     setup_requires=[setuptools_scm_requirement],
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ elif python_version >= (3, 6) and current_setuptools_version >= pkg_resources.pa
 scm_dict['fallback_version'] = get_version_by_import()
 
 setuptools.setup(
+    packages=find_namespace_package(include="eessi*")
     use_scm_version=scm_dict,
     setup_requires=[setuptools_scm_requirement],
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ elif python_version >= (3, 6) and current_setuptools_version >= pkg_resources.pa
 scm_dict['fallback_version'] = get_version_by_import()
 
 setuptools.setup(
-    packages=find_namespace_packages(include="eessi*"),
+    packages=setuptools.find_namespace_packages(include="eessi*"),
     use_scm_version=scm_dict,
     setup_requires=[setuptools_scm_requirement],
 )


### PR DESCRIPTION
I'm hitting an issue on Pyhon 3.12.3 when running anything that `pkg_resources` isn't present. Of course, we knew this would be deprecated. While using it in our `setup.py` is also awkward and it should eventually be removed there as well, that's not as urgent as removing it from this `__init__`, as having it here basically means not being able to import anything from the `eessi` namespace on systems that don't have `pkg_resources` anymore. (for the setup.py: we can always _build_ on a system with older python).

According to my AI friend, this call shouldn't even be needed if you have Python>=3.3, setuptools >= 28.8 and pip >= 9.0. I'm hoping that's true for everyone nowadays...