### PR TITLE
Put a try-guard around this import for newer pythons

### DIFF
--- a/eessi/__init__.py
+++ b/eessi/__init__.py
@@ -1,1 +1,9 @@
-__import__("pkg_resources").declare_namespace(__name__)
+# On older python's this is needed for correct installation of a namespace package
+# But on newer pythons, there is no pkg_resources anymore
+# We pragmatically wrap it in a try-block. It can be removed entirely after we stop supporting
+# python 3.6, since then we can simply require a new enough setuptools that this declare_namespace is
+# no longer required
+try:
+    __import__("pkg_resources").declare_namespace(__name__)
+except:
+    pass

--- a/eessi/__init__.py
+++ b/eessi/__init__.py
@@ -5,5 +5,5 @@
 # no longer required
 try:
     __import__("pkg_resources").declare_namespace(__name__)
-except:
+except ImportError:
     pass


### PR DESCRIPTION
I ran into issues on a system which had python 3.12, which lacks pkg_resources. Essentially, you can't import anything from the `eessi` namespace there