### PR TITLE
Remove setup.py pkg_resources dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42,<=81.0.0", "wheel"]
+requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,23 @@
-import setuptools
+import re
 import sys
-import pkg_resources
+
+import setuptools
+
+
+def version_at_least(version, minimum):
+    def normalize(value):
+        return [
+            (0, int(part)) if part.isdigit() else (1, part.lower())
+            for part in re.split(r"[._+-]", value)
+            if part
+        ]
+
+    version_parts = normalize(version)
+    minimum_parts = normalize(minimum)
+    length = max(len(version_parts), len(minimum_parts))
+    version_parts += [(0, 0)] * (length - len(version_parts))
+    minimum_parts += [(0, 0)] * (length - len(minimum_parts))
+    return version_parts >= minimum_parts
 
 
 def get_version_by_import():
@@ -16,21 +33,21 @@ python_version = sys.version_info
 # Get setuptools version
 # We control it when installing from pyproject.toml, but not when installing from setup.py / setup.cfg
 # Check setuptools version
-current_setuptools_version = pkg_resources.parse_version(pkg_resources.get_distribution("setuptools").version)
+current_setuptools_version = setuptools.__version__
 
 # Set the version requirement for setuptools_scm, depending on the combination of Python and setuptools version
 version_file_path = 'eessi/testsuite/_version.py'
 scm_dict = {'write_to': version_file_path}
-if python_version >= (3, 8) and current_setuptools_version >= pkg_resources.parse_version("61.0.0"):
+if python_version >= (3, 8) and version_at_least(current_setuptools_version, "61.0.0"):
     setuptools_scm_requirement = 'setuptools_scm>8.0.0,<=8.1.0'
     scm_dict = {'version_file': version_file_path}
-elif python_version >= (3, 7) and current_setuptools_version >= pkg_resources.parse_version("45.0.0"):
+elif python_version >= (3, 7) and version_at_least(current_setuptools_version, "45.0.0"):
     setuptools_scm_requirement = 'setuptools_scm>7.0.0,<=7.1.0'
-elif python_version >= (3, 6) and current_setuptools_version >= pkg_resources.parse_version("45.0.0"):
+elif python_version >= (3, 6) and version_at_least(current_setuptools_version, "45.0.0"):
     setuptools_scm_requirement = 'setuptools_scm>=6.0.0,<=6.4.2'
-elif python_version >= (3, 6) and current_setuptools_version >= pkg_resources.parse_version("42.0.0"):
+elif python_version >= (3, 6) and version_at_least(current_setuptools_version, "42.0.0"):
     setuptools_scm_requirement = 'setuptools_scm>=5.0.0,<=5.0.2'
-elif python_version >= (3, 6) and current_setuptools_version >= pkg_resources.parse_version("34.4.0"):
+elif python_version >= (3, 6) and version_at_least(current_setuptools_version, "34.4.0"):
     setuptools_scm_requirement = 'setuptools_scm>=4.0.0,<=4.1.2'
 
 # Set the fallback_version for scm based on what eessi.testsuite.__version__ returns


### PR DESCRIPTION
## Summary
- replace the `setup.py` `pkg_resources` version checks with `setuptools.__version__` and a small local version comparator
- remove the temporary `setuptools<=81.0.0` build-system cap now that `setup.py` no longer needs `pkg_resources`

Fixes #320

## Validation
- `rg -n "pkg_resources|get_distribution|parse_version|setuptools>=42" setup.py pyproject.toml eessi -S` (no `setup.py` `pkg_resources` usage remains; the remaining `pkg_resources` hit is the guarded namespace-package import in `eessi/__init__.py`)
- `git diff --check HEAD~1..HEAD`
- Not run locally
