### PR TITLE
Fix CI failure due to hpctestlib not being present in ReFrame 4.10 onwards

### DIFF
--- a/.github/workflows/pip_install.yml
+++ b/.github/workflows/pip_install.yml
@@ -32,7 +32,10 @@ jobs:
           run: |
             python -m pip install --user reframe-hpc
             # remove hpctestlib directory, which is automatically installed with reframe-hpc
-            pip show reframe-hpc | grep Location | cut -d ' ' -f 2 | xargs -I {} rm -r {}/hpctestlib
+            install_dir=$(pip show reframe-hpc | grep Location | cut -d ' ' -f 2)
+            if [ -d "$install_dir/hpctestlib" ]; then
+                rm -r "$install_dir/hpctestlib"
+            fi
 
         - name: Install EESSI test suite with 'pip install'
           run: |


### PR DESCRIPTION
Fix CI since hpctestlib is no longer included in ReFrame 4.10 onwards, which is installed for python 3.10 and newer. This caused the CI to fail for Python 3.10 and newer.

CI failed in e.g. https://github.com/EESSI/test-suite/pull/326/commits/baa4e8790c09c039916dfe9f8a6aa2db78223b20 