### PR TITLE
Fix issue where v0.9.0 was considered a higher version than v1.0.0

### DIFF
--- a/CI/run_reframe.sh
+++ b/CI/run_reframe.sh
@@ -49,7 +49,7 @@ if [ -z "${EESSI_TESTSUITE_BRANCH}" ]; then
     cd "${TEMPDIR}/test-suite-version-checkout"
     git fetch --tags
     # This assumes we stick to a version-tagging scheme vX.Y.Z
-    LATEST_VERSION=$(git tag | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -t. -k 1,1n -k 2,2n -k 3,3n | tail -1)
+    LATEST_VERSION=$(LATEST_VERSION=$(git tag --list 'v*' | sort -V | tail -n1)
     # Use the latest release by default
     EESSI_TESTSUITE_BRANCH="${LATEST_VERSION}"
     cd ${TEMPDIR}


### PR DESCRIPTION
Sort order with the original:

```
$ git tag | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -t. -k 1,1n -k 2,2n -k 3,3n
v1.0.0
v0.1.0
v0.2.0
v0.3.0
v0.3.1
v0.3.2
v0.4.0
v0.5.0
v0.5.1
v0.5.2
v0.6.0
v0.7.0
v0.7.1
v0.8.0
v0.8.1
v0.9.0
```

The issue is that `sort` is seeing `v0` and `v1` as a single entity, which, numerically, are both considered `0`. It then looks to the second field for sorting, hence `v1.0.0` is considered lower.

Sort order after this change:

```
$ git tag --list 'v*' | sort -V
v0.1.0
v0.2.0
v0.3.0
v0.3.1
v0.3.2
v0.4.0
v0.5.0
v0.5.1
v0.5.2
v0.6.0
v0.7.0
v0.7.1
v0.8.0
v0.8.1
v0.9.0
v1.0.0
```

`sort -V` is "natural sort of (version) numbers within text" according to the manual :)